### PR TITLE
Refactor engine pipeline into Nest services

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "./config/config.module";
+import { ContextModule } from "./core/context/context.module";
+import { EngineModule } from "./core/engine/engine.module";
+import { IoModule } from "./io/io.module";
+
+@Module({
+  imports: [ConfigModule, ContextModule, IoModule, EngineModule],
+})
+export class AppModule {}

--- a/src/cli/commands/ask.ts
+++ b/src/cli/commands/ask.ts
@@ -1,11 +1,17 @@
-import { runEngine } from "../../core/engine";
-import { resolveCliOptions } from "../utils";
+import { EngineService } from "../../core/engine";
+import { createCliApplicationContext, resolveCliOptions } from "../utils";
 
 export async function ask(
   prompt: string,
   options: Record<string, unknown>
 ): Promise<void> {
   const engineOptions = resolveCliOptions(options);
-  await runEngine(prompt, engineOptions);
+  const app = await createCliApplicationContext();
+  try {
+    const engine = app.get(EngineService);
+    await engine.run(prompt, engineOptions);
+  } finally {
+    await app.close();
+  }
 }
 

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -1,13 +1,15 @@
 import readline from "readline/promises";
 import { stdin as input, stdout as output } from "process";
-import { runEngine } from "../../core/engine";
-import { resolveCliOptions } from "../utils";
+import { EngineService } from "../../core/engine";
+import { createCliApplicationContext, resolveCliOptions } from "../utils";
 import type { ChatMessage } from "../../core/types";
 
 export async function chat(options: Record<string, unknown>): Promise<void> {
   const engineOptions = resolveCliOptions(options);
   const rl = readline.createInterface({ input, output });
   const history: ChatMessage[] = [];
+  const app = await createCliApplicationContext();
+  const engine = app.get(EngineService);
 
   try {
     while (true) {
@@ -17,7 +19,7 @@ export async function chat(options: Record<string, unknown>): Promise<void> {
         break;
       }
 
-      const result = await runEngine(prompt, { ...engineOptions, history });
+      const result = await engine.run(prompt, { ...engineOptions, history });
       const assistant = [...result.messages]
         .reverse()
         .find((message) => message.role === "assistant" && message.content.trim().length > 0);
@@ -31,5 +33,6 @@ export async function chat(options: Record<string, unknown>): Promise<void> {
     }
   } finally {
     rl.close();
+    await app.close();
   }
 }

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -1,35 +1,47 @@
-import { loadConfig } from "../../config/loader";
-import { packContext } from "../../core/context/packer";
-import { makeTokenizer } from "../../core/tokenizers/strategy";
-import { initLogging, getLogger } from "../../io/logger";
-import { resolveCliOptions } from "../utils";
+import { ConfigService } from "../../config/loader";
+import { ContextService } from "../../core/context/packer";
+import { TokenizerService } from "../../core/tokenizers/strategy";
+import { LoggerService } from "../../io/logger";
+import { createCliApplicationContext, resolveCliOptions } from "../utils";
 
 export async function context(
   options: Record<string, unknown>
 ): Promise<void> {
   const engineOptions = resolveCliOptions(options);
-  const cfg = await loadConfig(engineOptions);
-  initLogging({
-    level: cfg.logging?.level ?? cfg.logLevel,
-    destination: cfg.logging?.destination,
-    enableTimestamps: cfg.logging?.enableTimestamps,
-  });
-  const logger = getLogger("cli:context");
-  logger.debug({ include: cfg.context.include, exclude: cfg.context.exclude }, "Packing context preview");
-  const packed = await packContext(cfg.context);
+  const app = await createCliApplicationContext();
+  try {
+    const configService = app.get(ConfigService);
+    const loggerService = app.get(LoggerService);
+    const contextService = app.get(ContextService);
+    const tokenizerService = app.get(TokenizerService);
 
-  if (packed.files.length === 0) {
-    console.log("No context files matched the current configuration.");
-    return;
-  }
+    const cfg = await configService.load(engineOptions);
+    loggerService.configure({
+      level: cfg.logging?.level ?? cfg.logLevel,
+      destination: cfg.logging?.destination,
+      enableTimestamps: cfg.logging?.enableTimestamps,
+    });
+    const logger = loggerService.getLogger("cli:context");
+    logger.debug({ include: cfg.context.include, exclude: cfg.context.exclude }, "Packing context preview");
+    const packed = await contextService.pack(cfg.context);
 
-  const tokenizer = makeTokenizer(cfg.tokenizer?.provider ?? cfg.provider.name);
-  const tokens = tokenizer.countTokens(packed.text);
+    if (packed.files.length === 0) {
+      console.log("No context files matched the current configuration.");
+      return;
+    }
 
-  console.log(`Context preview (${packed.files.length} files, ${packed.totalBytes} bytes, ~${tokens} tokens)`);
-  console.log("────────────────────────────────────────────────────────");
+    const tokenizer = tokenizerService.create(
+      cfg.tokenizer?.provider ?? cfg.provider.name
+    );
+    const tokens = tokenizer.countTokens(packed.text);
 
-  for (const file of packed.files) {
-    console.log(`• ${file.path} (${file.bytes} bytes)`);
+    console.log(`Context preview (${packed.files.length} files, ${packed.totalBytes} bytes, ~${tokens} tokens)`);
+    console.log("────────────────────────────────────────────────────────");
+
+    for (const file of packed.files) {
+      console.log(`• ${file.path} (${file.bytes} bytes)`);
+    }
+  } finally {
+    await app.close();
   }
 }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -1,11 +1,17 @@
-import { runEngine } from "../../core/engine";
-import { resolveCliOptions } from "../utils";
+import { EngineService } from "../../core/engine";
+import { createCliApplicationContext, resolveCliOptions } from "../utils";
 
 export async function run(
   prompt: string,
   options: Record<string, unknown>
 ): Promise<void> {
   const engineOptions = resolveCliOptions(options);
-  await runEngine(prompt, engineOptions);
+  const app = await createCliApplicationContext();
+  try {
+    const engine = app.get(EngineService);
+    await engine.run(prompt, engineOptions);
+  } finally {
+    await app.close();
+  }
 }
 

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -1,13 +1,15 @@
 import fs from "fs/promises";
 import path from "path";
-import { resolveCliOptions } from "../utils";
-import { loadConfig } from "../../config/loader";
+import { ConfigService } from "../../config/loader";
+import { createCliApplicationContext, resolveCliOptions } from "../utils";
 
 export async function trace(
   options: Record<string, unknown>
 ): Promise<void> {
   const engineOptions = resolveCliOptions(options);
-  const cfg = await loadConfig(engineOptions);
+  const app = await createCliApplicationContext();
+  const configService = app.get(ConfigService);
+  const cfg = await configService.load(engineOptions);
 
   const tracePath =
     engineOptions.jsonlTrace ??
@@ -33,6 +35,8 @@ export async function trace(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Unable to read trace at ${tracePath}: ${message}`);
+  } finally {
+    await app.close();
   }
 }
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,3 +1,6 @@
+import type { INestApplicationContext } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "../app.module";
 import type { CliRuntimeOptions } from "../config/types";
 import type { EngineOptions } from "../core/engine";
 
@@ -52,4 +55,8 @@ export function resolveCliOptions(
     nonInteractive,
     tools,
   };
+}
+
+export async function createCliApplicationContext(): Promise<INestApplicationContext> {
+  return NestFactory.createApplicationContext(AppModule, { logger: false });
 }

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { ConfigService } from "./loader";
+
+@Module({
+  providers: [ConfigService],
+  exports: [ConfigService],
+})
+export class ConfigModule {}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,3 +1,4 @@
+import { Injectable } from "@nestjs/common";
 import fs from "fs/promises";
 import path from "path";
 import yaml from "yaml";
@@ -19,206 +20,210 @@ const CONFIG_FILENAMES = [
   ".eddierc.yaml",
 ];
 
-async function readConfigFile(candidate: string): Promise<EddieConfigInput> {
-  try {
-    const data = await fs.readFile(candidate, "utf-8");
-    if (candidate.endsWith(".yaml") || candidate.endsWith(".yml")) {
-      return (yaml.parse(data) ?? {}) as EddieConfigInput;
+@Injectable()
+export class ConfigService {
+  async load(options: CliRuntimeOptions): Promise<EddieConfig> {
+    const configPath = await this.resolveConfigPath(options);
+    const fileConfig = configPath ? await this.readConfigFile(configPath) : {};
+    const merged = this.mergeConfig(DEFAULT_CONFIG, fileConfig);
+    if (merged.logging?.level) {
+      merged.logLevel = merged.logging.level;
+    } else if (merged.logLevel) {
+      merged.logging = {
+        ...(merged.logging ?? {}),
+        level: merged.logLevel,
+      };
     }
-    if (candidate.endsWith(".json") || candidate.endsWith(".rc")) {
-      return JSON.parse(data) as EddieConfigInput;
-    }
+    return this.applyCliOverrides(merged, options);
+  }
+
+  private async readConfigFile(candidate: string): Promise<EddieConfigInput> {
     try {
-      return (yaml.parse(data) ?? {}) as EddieConfigInput;
+      const data = await fs.readFile(candidate, "utf-8");
+      if (candidate.endsWith(".yaml") || candidate.endsWith(".yml")) {
+        return (yaml.parse(data) ?? {}) as EddieConfigInput;
+      }
+      if (candidate.endsWith(".json") || candidate.endsWith(".rc")) {
+        return JSON.parse(data) as EddieConfigInput;
+      }
+      try {
+        return (yaml.parse(data) ?? {}) as EddieConfigInput;
+      } catch {
+        return JSON.parse(data) as EddieConfigInput;
+      }
     } catch {
-      return JSON.parse(data) as EddieConfigInput;
-    }
-  } catch {
-    return {};
-  }
-}
-
-async function resolveConfigPath(
-  options: CliRuntimeOptions
-): Promise<string | null> {
-  if (options.config) {
-    const explicit = path.resolve(options.config);
-    try {
-      await fs.access(explicit);
-      return explicit;
-    } catch {
-      throw new Error(`Config file not found at ${explicit}`);
+      return {};
     }
   }
 
-  for (const name of CONFIG_FILENAMES) {
-    const candidate = path.resolve(name);
-    try {
-      await fs.access(candidate);
-      return candidate;
-    } catch {
-      // keep searching
+  private async resolveConfigPath(
+    options: CliRuntimeOptions
+  ): Promise<string | null> {
+    if (options.config) {
+      const explicit = path.resolve(options.config);
+      try {
+        await fs.access(explicit);
+        return explicit;
+      } catch {
+        throw new Error(`Config file not found at ${explicit}`);
+      }
     }
+
+    for (const name of CONFIG_FILENAMES) {
+      const candidate = path.resolve(name);
+      try {
+        await fs.access(candidate);
+        return candidate;
+      } catch {
+        // keep searching
+      }
+    }
+
+    return null;
   }
 
-  return null;
-}
-
-function ensureContextShape(context: ContextConfig | undefined): ContextConfig {
-  return {
-    include: context?.include ?? [],
-    exclude: context?.exclude,
-    baseDir: context?.baseDir ?? process.cwd(),
-    maxBytes: context?.maxBytes,
-    maxFiles: context?.maxFiles,
-  };
-}
-
-function mergeConfig(
-  base: EddieConfig,
-  input: EddieConfigInput
-): EddieConfig {
-  const mergedContext = ensureContextShape({
-    ...base.context,
-    ...(input.context ?? {}),
-  });
-
-  const mergedLogging: LoggingConfig = {
-    level: base.logging?.level ?? base.logLevel,
-    destination: base.logging?.destination,
-    enableTimestamps: base.logging?.enableTimestamps,
-  };
-
-  if (input.logging?.destination) {
-    mergedLogging.destination = {
-      ...mergedLogging.destination,
-      ...input.logging.destination,
+  private ensureContextShape(
+    context: ContextConfig | undefined
+  ): ContextConfig {
+    return {
+      include: context?.include ?? [],
+      exclude: context?.exclude,
+      baseDir: context?.baseDir ?? process.cwd(),
+      maxBytes: context?.maxBytes,
+      maxFiles: context?.maxFiles,
     };
   }
 
-  if (typeof input.logging?.enableTimestamps !== "undefined") {
-    mergedLogging.enableTimestamps = input.logging.enableTimestamps;
-  }
+  private mergeConfig(
+    base: EddieConfig,
+    input: EddieConfigInput
+  ): EddieConfig {
+    const mergedContext = this.ensureContextShape({
+      ...base.context,
+      ...(input.context ?? {}),
+    });
 
-  const loggingLevel = input.logging?.level ?? input.logLevel ?? mergedLogging.level;
-  const effectiveLevel = loggingLevel ?? base.logLevel;
-  mergedLogging.level = effectiveLevel;
+    const mergedLogging: LoggingConfig = {
+      level: base.logging?.level ?? base.logLevel,
+      destination: base.logging?.destination,
+      enableTimestamps: base.logging?.enableTimestamps,
+    };
 
-  return {
-    ...base,
-    ...(input.model ? { model: input.model } : {}),
-    ...(input.systemPrompt ? { systemPrompt: input.systemPrompt } : {}),
-    provider: {
-      ...base.provider,
-      ...(input.provider ?? {}),
-    },
-    context: mergedContext,
-    output: {
-      ...base.output,
-      ...(input.output ?? {}),
-    },
-    tools: {
-      ...base.tools,
-      ...(input.tools ?? {}),
-    },
-    hooks: {
-      ...base.hooks,
-      ...(input.hooks ?? {}),
-    },
-    tokenizer: {
-      ...base.tokenizer,
-      ...(input.tokenizer ?? {}),
-    },
-    logging: mergedLogging,
-    logLevel: effectiveLevel,
-  };
-}
+    if (input.logging?.destination) {
+      mergedLogging.destination = {
+        ...mergedLogging.destination,
+        ...input.logging.destination,
+      };
+    }
 
-function applyCliOverrides(
-  config: EddieConfig,
-  options: CliRuntimeOptions
-): EddieConfig {
-  const merged = { ...config };
+    if (typeof input.logging?.enableTimestamps !== "undefined") {
+      mergedLogging.enableTimestamps = input.logging.enableTimestamps;
+    }
 
-  if (options.model) {
-    merged.model = options.model;
-  }
+    const loggingLevel =
+      input.logging?.level ?? input.logLevel ?? mergedLogging.level;
+    const effectiveLevel = loggingLevel ?? base.logLevel;
+    mergedLogging.level = effectiveLevel;
 
-  if (options.provider) {
-    merged.provider = {
-      ...merged.provider,
-      name: options.provider,
+    return {
+      ...base,
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.systemPrompt ? { systemPrompt: input.systemPrompt } : {}),
+      provider: {
+        ...base.provider,
+        ...(input.provider ?? {}),
+      },
+      context: mergedContext,
+      output: {
+        ...base.output,
+        ...(input.output ?? {}),
+      },
+      tools: {
+        ...base.tools,
+        ...(input.tools ?? {}),
+      },
+      hooks: {
+        ...base.hooks,
+        ...(input.hooks ?? {}),
+      },
+      tokenizer: {
+        ...base.tokenizer,
+        ...(input.tokenizer ?? {}),
+      },
+      logging: mergedLogging,
+      logLevel: effectiveLevel,
     };
   }
 
-  if (options.context?.length) {
-    merged.context = {
-      ...merged.context,
-      include: options.context,
-    };
-  }
+  private applyCliOverrides(
+    config: EddieConfig,
+    options: CliRuntimeOptions
+  ): EddieConfig {
+    const merged = { ...config };
 
-  if (options.tools?.length) {
-    merged.tools = {
-      ...(merged.tools ?? {}),
-      enabled: options.tools,
-    };
-  }
+    if (options.model) {
+      merged.model = options.model;
+    }
 
-  if (typeof options.autoApprove === "boolean") {
-    merged.tools = {
-      ...(merged.tools ?? {}),
-      autoApprove: options.autoApprove,
-    };
-  }
+    if (options.provider) {
+      merged.provider = {
+        ...merged.provider,
+        name: options.provider,
+      };
+    }
 
-  if (options.jsonlTrace) {
-    merged.output = {
-      ...(merged.output ?? {}),
-      jsonlTrace: options.jsonlTrace,
-    };
-  }
+    if (options.context?.length) {
+      merged.context = {
+        ...merged.context,
+        include: options.context,
+      };
+    }
 
-  if (options.logLevel) {
-    merged.logLevel = options.logLevel;
-    merged.logging = {
-      ...(merged.logging ?? { level: options.logLevel }),
-      level: options.logLevel,
-    };
-  } else if (merged.logging?.level) {
-    merged.logLevel = merged.logging.level;
-  }
+    if (options.tools?.length) {
+      merged.tools = {
+        ...(merged.tools ?? {}),
+        enabled: options.tools,
+      };
+    }
 
-  if (options.logFile) {
-    const destination = {
-      ...(merged.logging?.destination ?? {}),
-      type: "file" as const,
-      path: options.logFile,
-      pretty: false,
-      colorize: false,
-    };
-    merged.logging = {
-      ...(merged.logging ?? { level: merged.logLevel }),
-      destination,
-    };
-  }
+    if (typeof options.autoApprove === "boolean") {
+      merged.tools = {
+        ...(merged.tools ?? {}),
+        autoApprove: options.autoApprove,
+      };
+    }
 
-  return merged;
-}
+    if (options.jsonlTrace) {
+      merged.output = {
+        ...(merged.output ?? {}),
+        jsonlTrace: options.jsonlTrace,
+      };
+    }
 
-export async function loadConfig(
-  options: CliRuntimeOptions
-): Promise<EddieConfig> {
-  const configPath = await resolveConfigPath(options);
-  const fileConfig = configPath ? await readConfigFile(configPath) : {};
-  const merged = mergeConfig(DEFAULT_CONFIG, fileConfig);
-  if (merged.logging?.level) {
-    merged.logLevel = merged.logging.level;
-  } else if (merged.logLevel) {
-    merged.logging = {
-      ...(merged.logging ?? {}),
-      level: merged.logLevel,
-    };
+    if (options.logLevel) {
+      merged.logLevel = options.logLevel;
+      merged.logging = {
+        ...(merged.logging ?? { level: options.logLevel }),
+        level: options.logLevel,
+      };
+    } else if (merged.logging?.level) {
+      merged.logLevel = merged.logging.level;
+    }
+
+    if (options.logFile) {
+      const destination = {
+        ...(merged.logging?.destination ?? {}),
+        type: "file" as const,
+        path: options.logFile,
+        pretty: false,
+        colorize: false,
+      };
+      merged.logging = {
+        ...(merged.logging ?? { level: merged.logLevel }),
+        destination,
+      };
+    }
+
+    return merged;
   }
-  return applyCliOverrides(merged, options);
 }

--- a/src/core/context/context.module.ts
+++ b/src/core/context/context.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { IoModule } from "../../io/io.module";
+import { ContextService } from "./packer";
+
+@Module({
+  imports: [IoModule],
+  providers: [ContextService],
+  exports: [ContextService],
+})
+export class ContextModule {}

--- a/src/core/context/packer.ts
+++ b/src/core/context/packer.ts
@@ -1,76 +1,82 @@
+import { Injectable } from "@nestjs/common";
 import fs from "fs/promises";
 import path from "path";
 import fg from "fast-glob";
 import ignore from "ignore";
 import type { ContextConfig } from "../../config/types";
 import type { PackedContext } from "../types";
-import { getLogger } from "../../io/logger";
+import { LoggerService } from "../../io/logger";
 
 const DEFAULT_MAX_BYTES = 250_000;
 const DEFAULT_MAX_FILES = 64;
 
-export async function packContext(config: ContextConfig): Promise<PackedContext> {
-  const logger = getLogger("context:packer");
-  const baseDir = config.baseDir ?? process.cwd();
-  const includePatterns = config.include?.length ? config.include : ["**/*"];
-  const excludePatterns = config.exclude ?? [];
-  const maxBytes = config.maxBytes ?? DEFAULT_MAX_BYTES;
-  const maxFiles = config.maxFiles ?? DEFAULT_MAX_FILES;
+@Injectable()
+export class ContextService {
+  constructor(private readonly loggerService: LoggerService) {}
 
-  const globResults = await fg(includePatterns, {
-    cwd: baseDir,
-    dot: true,
-    onlyFiles: true,
-  });
+  async pack(config: ContextConfig): Promise<PackedContext> {
+    const logger = this.loggerService.getLogger("context:packer");
+    const baseDir = config.baseDir ?? process.cwd();
+    const includePatterns = config.include?.length ? config.include : ["**/*"];
+    const excludePatterns = config.exclude ?? [];
+    const maxBytes = config.maxBytes ?? DEFAULT_MAX_BYTES;
+    const maxFiles = config.maxFiles ?? DEFAULT_MAX_FILES;
 
-  const ig = ignore().add(excludePatterns);
+    const globResults = await fg(includePatterns, {
+      cwd: baseDir,
+      dot: true,
+      onlyFiles: true,
+    });
 
-  const files: PackedContext["files"] = [];
-  let totalBytes = 0;
+    const ig = ignore().add(excludePatterns);
 
-  for (const relPath of globResults) {
-    if (files.length >= maxFiles) {
-      logger.debug(`Context file limit reached (${maxFiles}).`);
-      break;
-    }
+    const files: PackedContext["files"] = [];
+    let totalBytes = 0;
 
-    if (ig.ignores(relPath)) {
-      continue;
-    }
+    for (const relPath of globResults) {
+      if (files.length >= maxFiles) {
+        logger.debug(`Context file limit reached (${maxFiles}).`);
+        break;
+      }
 
-    const absolutePath = path.resolve(baseDir, relPath);
-    try {
-      const content = await fs.readFile(absolutePath, "utf-8");
-      const bytes = Buffer.byteLength(content);
-      if (totalBytes + bytes > maxBytes) {
-        logger.debug({ file: relPath, maxBytes }, "Skipping file beyond budget");
+      if (ig.ignores(relPath)) {
         continue;
       }
 
-      files.push({
-        path: relPath,
-        bytes,
-        content,
-      });
-      totalBytes += bytes;
-    } catch (error) {
-      logger.warn(
-        { err: error instanceof Error ? error.message : error, file: relPath },
-        "Failed to read context file"
-      );
+      const absolutePath = path.resolve(baseDir, relPath);
+      try {
+        const content = await fs.readFile(absolutePath, "utf-8");
+        const bytes = Buffer.byteLength(content);
+        if (totalBytes + bytes > maxBytes) {
+          logger.debug({ file: relPath, maxBytes }, "Skipping file beyond budget");
+          continue;
+        }
+
+        files.push({
+          path: relPath,
+          bytes,
+          content,
+        });
+        totalBytes += bytes;
+      } catch (error) {
+        logger.warn(
+          { err: error instanceof Error ? error.message : error, file: relPath },
+          "Failed to read context file"
+        );
+      }
     }
+
+    const text = files
+      .map(
+        (file) =>
+          `// File: ${file.path}\n${file.content.trimEnd()}\n// End of ${file.path}`
+      )
+      .join("\n\n");
+
+    return {
+      files,
+      totalBytes,
+      text,
+    };
   }
-
-  const text = files
-    .map(
-      (file) =>
-        `// File: ${file.path}\n${file.content.trimEnd()}\n// End of ${file.path}`
-    )
-    .join("\n\n");
-
-  return {
-    files,
-    totalBytes,
-    text,
-  };
 }

--- a/src/core/engine/engine.module.ts
+++ b/src/core/engine/engine.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "../../config/config.module";
+import { ContextModule } from "../context/context.module";
+import { IoModule } from "../../io/io.module";
+import { EngineService } from "../engine";
+import { ProviderFactory } from "../providers";
+import { ToolRegistryFactory } from "../tools/registry";
+import { HooksService } from "../../hooks/loader";
+import { TokenizerService } from "../tokenizers/strategy";
+
+@Module({
+  imports: [ConfigModule, ContextModule, IoModule],
+  providers: [EngineService, ProviderFactory, ToolRegistryFactory, HooksService, TokenizerService],
+  exports: [EngineService, ProviderFactory, ToolRegistryFactory, HooksService, TokenizerService],
+})
+export class EngineModule {}

--- a/src/core/providers/index.ts
+++ b/src/core/providers/index.ts
@@ -1,26 +1,30 @@
+import { Injectable } from "@nestjs/common";
 import type { ProviderAdapter } from "../types";
 import { OpenAIAdapter } from "./openai";
 import { AnthropicAdapter } from "./anthropic";
 import { OpenAICompatibleAdapter } from "./openai_compatible";
 import type { ProviderConfig } from "../../config/types";
 
-export function makeProvider(config: ProviderConfig): ProviderAdapter {
-  switch (config.name) {
-    case "openai":
-      return new OpenAIAdapter(config);
-    case "anthropic":
-      return new AnthropicAdapter(config);
-    case "openai_compatible":
-      return new OpenAICompatibleAdapter(config);
-    case "noop":
-      return {
-        name: "noop",
-        async *stream() {
-          yield { type: "error", message: "No provider configured" } as const;
-        },
-      };
-    default:
-      throw new Error(`Unknown provider: ${config.name}`);
+@Injectable()
+export class ProviderFactory {
+  create(config: ProviderConfig): ProviderAdapter {
+    switch (config.name) {
+      case "openai":
+        return new OpenAIAdapter(config);
+      case "anthropic":
+        return new AnthropicAdapter(config);
+      case "openai_compatible":
+        return new OpenAICompatibleAdapter(config);
+      case "noop":
+        return {
+          name: "noop",
+          async *stream() {
+            yield { type: "error", message: "No provider configured" } as const;
+          },
+        };
+      default:
+        throw new Error(`Unknown provider: ${config.name}`);
+    }
   }
 }
 

--- a/src/core/tokenizers/strategy.ts
+++ b/src/core/tokenizers/strategy.ts
@@ -1,3 +1,5 @@
+import { Injectable } from "@nestjs/common";
+
 export interface TokenizerStrategy {
   countTokens(text: string): number;
 }
@@ -14,10 +16,13 @@ export class AnthropicTokenizer implements TokenizerStrategy {
   }
 }
 
-export function makeTokenizer(provider: string): TokenizerStrategy {
-  if (provider === "anthropic") {
-    return new AnthropicTokenizer();
+@Injectable()
+export class TokenizerService {
+  create(provider: string): TokenizerStrategy {
+    if (provider === "anthropic") {
+      return new AnthropicTokenizer();
+    }
+    return new OpenAITokenizer();
   }
-  return new OpenAITokenizer();
 }
 

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -1,3 +1,4 @@
+import { Injectable } from "@nestjs/common";
 import Ajv, { type ValidateFunction } from "ajv";
 import type { ToolDefinition, ToolSchema } from "../types";
 
@@ -77,5 +78,12 @@ export class ToolRegistry {
     }
 
     return tool.handler(parsedArgs, ctx);
+  }
+}
+
+@Injectable()
+export class ToolRegistryFactory {
+  create(definitions: ToolDefinition[] = []): ToolRegistry {
+    return new ToolRegistry(definitions);
   }
 }

--- a/src/io/confirm.ts
+++ b/src/io/confirm.ts
@@ -1,3 +1,4 @@
+import { Injectable } from "@nestjs/common";
 import readline from "readline";
 
 export interface ConfirmOptions {
@@ -5,29 +6,32 @@ export interface ConfirmOptions {
   nonInteractive?: boolean;
 }
 
-export function createConfirm(options: ConfirmOptions) {
-  const autoApprove = options.autoApprove ?? false;
-  const nonInteractive = options.nonInteractive ?? false;
+@Injectable()
+export class ConfirmService {
+  create(options: ConfirmOptions) {
+    const autoApprove = options.autoApprove ?? false;
+    const nonInteractive = options.nonInteractive ?? false;
 
-  return async (message: string): Promise<boolean> => {
-    if (autoApprove) {
-      return true;
-    }
-    if (nonInteractive) {
-      return false;
-    }
+    return async (message: string): Promise<boolean> => {
+      if (autoApprove) {
+        return true;
+      }
+      if (nonInteractive) {
+        return false;
+      }
 
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
 
-    const answer: string = await new Promise((resolve) => {
-      rl.question(`${message} [y/N] `, resolve);
-    });
+      const answer: string = await new Promise((resolve) => {
+        rl.question(`${message} [y/N] `, resolve);
+      });
 
-    rl.close();
-    return /^y(es)?$/i.test(answer.trim());
-  };
+      rl.close();
+      return /^y(es)?$/i.test(answer.trim());
+    };
+  }
 }
 

--- a/src/io/io.module.ts
+++ b/src/io/io.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { ConfirmService } from "./confirm";
+import { JsonlWriterService } from "./jsonl_writer";
+import { LoggerService } from "./logger";
+import { StreamRendererService } from "./stream_renderer";
+
+@Module({
+  providers: [LoggerService, ConfirmService, JsonlWriterService, StreamRendererService],
+  exports: [LoggerService, ConfirmService, JsonlWriterService, StreamRendererService],
+})
+export class IoModule {}

--- a/src/io/jsonl_writer.ts
+++ b/src/io/jsonl_writer.ts
@@ -1,22 +1,22 @@
+import { Injectable } from "@nestjs/common";
 import fs from "fs/promises";
 import path from "path";
 
-async function ensureDirectory(filePath: string): Promise<void> {
-  const dir = path.dirname(filePath);
-  await fs.mkdir(dir, { recursive: true });
-}
+@Injectable()
+export class JsonlWriterService {
+  async write(filePath: string, event: unknown, append = true): Promise<void> {
+    await this.ensureDirectory(filePath);
+    const payload = `${JSON.stringify(event)}\n`;
+    if (append) {
+      await fs.appendFile(filePath, payload, "utf-8");
+    } else {
+      await fs.writeFile(filePath, payload, "utf-8");
+    }
+  }
 
-export async function writeJSONL(
-  filePath: string,
-  event: unknown,
-  append = true
-): Promise<void> {
-  await ensureDirectory(filePath);
-  const payload = `${JSON.stringify(event)}\n`;
-  if (append) {
-    await fs.appendFile(filePath, payload, "utf-8");
-  } else {
-    await fs.writeFile(filePath, payload, "utf-8");
+  private async ensureDirectory(filePath: string): Promise<void> {
+    const dir = path.dirname(filePath);
+    await fs.mkdir(dir, { recursive: true });
   }
 }
 

--- a/src/io/logger.ts
+++ b/src/io/logger.ts
@@ -1,95 +1,107 @@
+import { Injectable } from "@nestjs/common";
 import fs from "fs";
 import path from "path";
 import pino, { type Logger, type LoggerOptions } from "pino";
 import type { LoggingConfig, LoggingDestination } from "../config/types";
 
-let rootLogger: Logger | null = null;
-let cachedSignature = "";
+@Injectable()
+export class LoggerService {
+  private rootLogger: Logger | null = null;
+  private cachedSignature = "";
 
-function computeSignature(config?: LoggingConfig): string {
-  return JSON.stringify(config ?? {});
-}
-
-function resolvePrettyTransport(destination?: LoggingDestination): LoggerOptions["transport"] {
-  const wantsPretty = destination?.pretty ?? (destination?.type !== "file" && process.stdout.isTTY);
-  if (!wantsPretty) return undefined;
-
-  try {
-    require.resolve("pino-pretty");
-    return {
-      target: "pino-pretty",
-      options: {
-        colorize: destination?.colorize ?? true,
-        translateTime: "HH:MM:ss",
-        ignore: "pid,hostname",
-      },
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-function prepareDestination(destination?: LoggingDestination) {
-  if (!destination) return undefined;
-
-  switch (destination.type) {
-    case "stdout":
-      return pino.destination({ fd: 1 });
-    case "stderr":
-      return pino.destination({ fd: 2 });
-    case "file": {
-      const filePath = path.resolve(destination.path ?? ".eddie/logs/eddie.log");
-      fs.mkdirSync(path.dirname(filePath), { recursive: true });
-      return pino.destination({ dest: filePath, sync: false });
+  configure(config?: LoggingConfig): Logger {
+    const signature = this.computeSignature(config);
+    if (this.rootLogger && signature === this.cachedSignature) {
+      return this.rootLogger;
     }
-    default:
+    this.rootLogger = this.buildLogger(config);
+    this.cachedSignature = signature;
+    return this.rootLogger;
+  }
+
+  getLogger(scope?: string): Logger {
+    if (!this.rootLogger) {
+      this.rootLogger = this.buildLogger();
+    }
+    if (!scope) {
+      return this.rootLogger;
+    }
+    return this.rootLogger.child({ scope });
+  }
+
+  withBindings(bindings: Record<string, unknown>): Logger {
+    return this.getLogger().child(bindings);
+  }
+
+  reset(): void {
+    this.rootLogger = null;
+    this.cachedSignature = "";
+  }
+
+  private computeSignature(config?: LoggingConfig): string {
+    return JSON.stringify(config ?? {});
+  }
+
+  private resolvePrettyTransport(
+    destination?: LoggingDestination
+  ): LoggerOptions["transport"] {
+    const wantsPretty =
+      destination?.pretty ?? (destination?.type !== "file" && process.stdout.isTTY);
+    if (!wantsPretty) return undefined;
+
+    try {
+      require.resolve("pino-pretty");
+      return {
+        target: "pino-pretty",
+        options: {
+          colorize: destination?.colorize ?? true,
+          translateTime: "HH:MM:ss",
+          ignore: "pid,hostname",
+        },
+      };
+    } catch {
       return undefined;
-  }
-}
-
-function buildLogger(config?: LoggingConfig): Logger {
-  const level = config?.level ?? "info";
-  const destination = config?.destination;
-  const options: LoggerOptions = {
-    level: level === "silent" ? "silent" : level,
-    base: undefined,
-    timestamp: config?.enableTimestamps === false ? false : pino.stdTimeFunctions.isoTime,
-  };
-
-  const transport = resolvePrettyTransport(destination);
-  if (transport) {
-    options.transport = transport;
+    }
   }
 
-  const destStream = transport ? undefined : prepareDestination(destination);
-  return destStream ? pino(options, destStream) : pino(options);
-}
+  private prepareDestination(destination?: LoggingDestination) {
+    if (!destination) return undefined;
 
-export function initLogging(config?: LoggingConfig): Logger {
-  const signature = computeSignature(config);
-  if (rootLogger && signature === cachedSignature) {
-    return rootLogger;
+    switch (destination.type) {
+      case "stdout":
+        return pino.destination({ fd: 1 });
+      case "stderr":
+        return pino.destination({ fd: 2 });
+      case "file": {
+        const filePath = path.resolve(
+          destination.path ?? ".eddie/logs/eddie.log"
+        );
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        return pino.destination({ dest: filePath, sync: false });
+      }
+      default:
+        return undefined;
+    }
   }
-  rootLogger = buildLogger(config);
-  cachedSignature = signature;
-  return rootLogger;
-}
 
-export function getLogger(scope?: string): Logger {
-  if (!rootLogger) {
-    rootLogger = buildLogger();
+  private buildLogger(config?: LoggingConfig): Logger {
+    const level = config?.level ?? "info";
+    const destination = config?.destination;
+    const options: LoggerOptions = {
+      level: level === "silent" ? "silent" : level,
+      base: undefined,
+      timestamp:
+        config?.enableTimestamps === false
+          ? false
+          : pino.stdTimeFunctions.isoTime,
+    };
+
+    const transport = this.resolvePrettyTransport(destination);
+    if (transport) {
+      options.transport = transport;
+    }
+
+    const destStream = transport ? undefined : this.prepareDestination(destination);
+    return destStream ? pino(options, destStream) : pino(options);
   }
-  if (!scope) {
-    return rootLogger;
-  }
-  return rootLogger.child({ scope });
-}
-
-export function withBindings(bindings: Record<string, unknown>): Logger {
-  return getLogger().child(bindings);
-}
-
-export function resetLogging(): void {
-  rootLogger = null;
-  cachedSignature = "";
 }

--- a/src/io/stream_renderer.ts
+++ b/src/io/stream_renderer.ts
@@ -1,3 +1,4 @@
+import { Injectable } from "@nestjs/common";
 import chalk from "chalk";
 import type { StreamEvent } from "../core/types";
 import { redactSecrets } from "./redact";
@@ -5,48 +6,50 @@ import { redactSecrets } from "./redact";
 const DEFAULT_PATTERNS = [
   /sk-[A-Za-z0-9]{20,}/g,
   /ghp_[A-Za-z0-9]{20,}/g,
-  /AIza[0-9A-Za-z\\-_]{35}/g,
+  /AIza[0-9A-Za-z\-_]{35}/g,
 ];
 
-export function streamRender(event: StreamEvent): void {
-  switch (event.type) {
-    case "delta": {
-      process.stdout.write(event.text);
-      break;
+@Injectable()
+export class StreamRendererService {
+  render(event: StreamEvent): void {
+    switch (event.type) {
+      case "delta": {
+        process.stdout.write(event.text);
+        break;
+      }
+      case "tool_call": {
+        const args =
+          typeof event.arguments === "string"
+            ? event.arguments
+            : JSON.stringify(event.arguments, null, 2);
+        const redacted = redactSecrets(args, DEFAULT_PATTERNS);
+        process.stdout.write(
+          `\n${chalk.cyan("[tool_call]")} ${event.name} ${redacted}\n`
+        );
+        break;
+      }
+      case "tool_result": {
+        const summary =
+          typeof event.result === "string"
+            ? event.result
+            : JSON.stringify(event.result, null, 2);
+        process.stdout.write(
+          `\n${chalk.green("[tool_result]")} ${event.name} ${summary}\n`
+        );
+        break;
+      }
+      case "error": {
+        process.stderr.write(
+          `\n${chalk.red("[error]")} ${event.message}\n${event.cause ?? ""}\n`
+        );
+        break;
+      }
+      case "end": {
+        process.stdout.write(`\n${chalk.gray("[done]")}\n`);
+        break;
+      }
+      default:
+        break;
     }
-    case "tool_call": {
-      const args =
-        typeof event.arguments === "string"
-          ? event.arguments
-          : JSON.stringify(event.arguments, null, 2);
-      const redacted = redactSecrets(args, DEFAULT_PATTERNS);
-      process.stdout.write(
-        `\n${chalk.cyan("[tool_call]")} ${event.name} ${redacted}\n`
-      );
-      break;
-    }
-    case "tool_result": {
-      const summary =
-        typeof event.result === "string"
-          ? event.result
-          : JSON.stringify(event.result, null, 2);
-      process.stdout.write(
-        `\n${chalk.green("[tool_result]")} ${event.name} ${summary}\n`
-      );
-      break;
-    }
-    case "error": {
-      process.stderr.write(
-        `\n${chalk.red("[error]")} ${event.message}\n${event.cause ?? ""}\n`
-      );
-      break;
-    }
-    case "end": {
-      process.stdout.write(`\n${chalk.gray("[done]")}\n`);
-      break;
-    }
-    default:
-      break;
   }
 }
-

--- a/test/unit/context.test.ts
+++ b/test/unit/context.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import fs from "fs/promises";
 import path from "path";
-import { packContext } from "../../src/core/context/packer";
+import { ContextService } from "../../src/core/context/packer";
+import { LoggerService } from "../../src/io/logger";
 
 const tmpDir = path.join(process.cwd(), "test-temp");
+const loggerService = new LoggerService();
+const contextService = new ContextService(loggerService);
 
 beforeAll(async () => {
   await fs.mkdir(tmpDir, { recursive: true });
@@ -13,11 +16,12 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true });
+  loggerService.reset();
 });
 
 describe("packContext", () => {
   it("collects files according to include patterns", async () => {
-    const packed = await packContext({
+    const packed = await contextService.pack({
       include: ["*.ts"],
       baseDir: tmpDir,
     });

--- a/test/unit/logger.test.ts
+++ b/test/unit/logger.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
-import { getLogger, initLogging, resetLogging } from "../../src/io/logger";
+import { LoggerService } from "../../src/io/logger";
+
+const loggerService = new LoggerService();
 
 afterEach(async () => {
-  resetLogging();
+  loggerService.reset();
   const tmpDir = path.join(process.cwd(), "test-logs");
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
@@ -13,7 +15,7 @@ describe("logging framework", () => {
   it("writes logs to a configured file destination", async () => {
     const logPath = path.join(process.cwd(), "test-logs", "eddie.log");
 
-    initLogging({
+    loggerService.configure({
       level: "info",
       destination: {
         type: "file",
@@ -21,7 +23,7 @@ describe("logging framework", () => {
       },
     });
 
-    const logger = getLogger("test");
+    const logger = loggerService.getLogger("test");
     logger.info({ check: true }, "file logging works");
 
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -31,8 +33,8 @@ describe("logging framework", () => {
   });
 
   it("returns scoped child loggers", () => {
-    initLogging({ level: "info" });
-    const logger = getLogger("engine");
+    loggerService.configure({ level: "info" });
+    const logger = loggerService.getLogger("engine");
     const child = logger.child({ requestId: "123" });
     expect(child.bindings()).toMatchObject({ scope: "engine", requestId: "123" });
   });


### PR DESCRIPTION
## Summary
- add application, config, context, IO, and engine Nest modules to expose injectable services
- wrap configuration loading, context packing, providers, tokenizers, hooks, and IO helpers in Nest services and refactor engine into EngineService
- update CLI commands and tests to resolve services through a Nest application context

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e504414d40832887be2f331b5a5cc0