### PR TITLE
refactor: reorganize engine service and release 1.0.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Eddie acts as a command-line facilitator for agentic AI workflows. This document
 CLI (commander)
   ├─ ask/run/chat/context/trace commands
   └─ resolveCliOptions → Engine
-Engine (src/core/engine.ts)
+Engine (src/core/engine)
   ├─ loadConfig → config/loader.ts (merges defaults + file + CLI flags)
   ├─ packContext → core/context/packer.ts (glob, ignore, budgets)
   ├─ makeProvider → core/providers/* (adapter pattern)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,8 @@
 ### Added
 - Integration tests covering the Nest-backed command runner and CLI argument parsing parity.
 - Migration guide documenting environment variables, configuration lookups, and build steps for downstream consumers.
+
+## [1.0.1] - 2025-10-07
+
+### Changed
+- Moved `EngineService` and related types into `src/core/engine/engine.service.ts` with a barrel export for downstream consumers.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Provider-agnostic AI assistant for the command line. Eddie hydrates prompts with
 2. Execute commands through the compiled binary (or via `npm exec eddie`):
 
    ```bash
-   node dist/main.js ask "Summarize src/core/engine.ts"
+   node dist/main.js ask "Summarize src/core/engine/engine.service.ts"
    # or
    npm exec -- eddie context --context "src/**/*.ts"
    ```
@@ -30,7 +30,7 @@ Provider-agnostic AI assistant for the command line. Eddie hydrates prompts with
 3. For local development with hot-reload, start the Nest CLI wrapper:
 
    ```bash
-   npm run dev -- ask "Summarize src/core/engine.ts"
+   npm run dev -- ask "Summarize src/core/engine/engine.service.ts"
    ```
 
 ## Configuration

--- a/docs/adr/0001-engine-service-module-refactor.md
+++ b/docs/adr/0001-engine-service-module-refactor.md
@@ -1,0 +1,19 @@
+# ADR 0001: Extract EngineService Into Dedicated Module Boundary
+
+## Status
+
+Accepted
+
+## Context
+
+The initial Nest refactor left `EngineService`, its options, and result types defined in `src/core/engine.ts` at the root of the `core` module. As additional engine-specific providers (e.g., the `EngineModule`) matured, that flat structure made the dependency graph harder to navigate and complicated tree-shaking. We now maintain other engine concerns inside `src/core/engine/`, so colocating the service aligns with the established folder boundaries.
+
+## Decision
+
+We relocated the `EngineService` implementation—and the `EngineOptions` and `EngineResult` types—into `src/core/engine/engine.service.ts`. A new barrel file at `src/core/engine/index.ts` re-exports those symbols for existing consumers, while the `EngineModule` imports the service locally. Downstream imports (CLI commands, CLI options service, and integration tests) now resolve via the barrel file instead of reaching into a specific file path.
+
+## Consequences
+
+- Engine-related code now lives within a single directory, improving discoverability and keeping Nest module wiring close to the implementation.
+- Consumers benefit from a stable module entry point (`src/core/engine`) that hides file structure changes, easing future refactors.
+- The structural change required updates to documentation and build metadata, but no runtime behaviour was modified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eddie",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eddie",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
                 "@nestjs/common": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eddie",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "dist/main.js",
     "bin": {
         "eddie": "dist/main.js"

--- a/src/core/engine/engine.module.ts
+++ b/src/core/engine/engine.module.ts
@@ -2,7 +2,7 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "../../config/config.module";
 import { ContextModule } from "../context/context.module";
 import { IoModule } from "../../io/io.module";
-import { EngineService } from "../engine";
+import { EngineService } from "./engine.service";
 import { ProviderFactory } from "../providers";
 import { ToolRegistryFactory } from "../tools/registry";
 import { HooksService } from "../../hooks/loader";

--- a/src/core/engine/engine.service.ts
+++ b/src/core/engine/engine.service.ts
@@ -1,19 +1,19 @@
 import { Injectable } from "@nestjs/common";
 import path from "path";
-import type { CliRuntimeOptions } from "../config/types";
-import { ConfigService } from "../config/loader";
-import { ContextService } from "./context/packer";
-import { ProviderFactory } from "./providers";
-import { ToolRegistryFactory } from "./tools/registry";
-import { builtinTools } from "./tools/builtin";
-import { StreamRendererService } from "../io/stream_renderer";
-import { JsonlWriterService } from "../io/jsonl_writer";
-import { HooksService } from "../hooks/loader";
-import type { ChatMessage, StreamEvent } from "./types";
-import type { PackedContext } from "./types";
-import { ConfirmService } from "../io/confirm";
-import { TokenizerService } from "./tokenizers/strategy";
-import { LoggerService } from "../io/logger";
+import type { CliRuntimeOptions } from "../../config/types";
+import { ConfigService } from "../../config/loader";
+import { ContextService } from "../context/packer";
+import { ProviderFactory } from "../providers";
+import { ToolRegistryFactory } from "../tools/registry";
+import { builtinTools } from "../tools/builtin";
+import { StreamRendererService } from "../../io/stream_renderer";
+import { JsonlWriterService } from "../../io/jsonl_writer";
+import { HooksService } from "../../hooks/loader";
+import type { ChatMessage, StreamEvent } from "../types";
+import type { PackedContext } from "../types";
+import { ConfirmService } from "../../io/confirm";
+import { TokenizerService } from "../tokenizers/strategy";
+import { LoggerService } from "../../io/logger";
 
 export interface EngineOptions extends CliRuntimeOptions {
   history?: ChatMessage[];
@@ -27,6 +27,11 @@ export interface EngineResult {
   tracePath?: string;
 }
 
+/**
+ * EngineService orchestrates the full CLI execution flow by layering configuration,
+ * preparing context, invoking the selected provider, and coordinating tool usage
+ * and trace emission.
+ */
 @Injectable()
 export class EngineService {
   constructor(

--- a/src/core/engine/index.ts
+++ b/src/core/engine/index.ts
@@ -1,0 +1,2 @@
+export { EngineService } from "./engine.service";
+export type { EngineOptions, EngineResult } from "./engine.service";


### PR DESCRIPTION
## Summary
- move the EngineService implementation into src/core/engine/engine.service.ts and export it via a new barrel file
- update module wiring, documentation, and record the decision in a new ADR
- bump the package version to 1.0.1 and note the refactor in the changelog

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e51052871083288b84f8067b453ce9