### PR TITLE
refactor: rename context packer service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ CLI (commander)
   └─ resolveCliOptions → Engine
 Engine (src/core/engine)
   ├─ loadConfig → config/loader.ts (merges defaults + file + CLI flags)
-  ├─ packContext → core/context/packer.ts (glob, ignore, budgets)
+  ├─ ContextService → core/context/context.service.ts (glob, ignore, budgets)
   ├─ makeProvider → core/providers/* (adapter pattern)
   ├─ ToolRegistry → core/tools/* (AJV validated tool calls)
   ├─ stream loop → handles deltas, tool calls, traces, hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Integration tests covering the Nest-backed command runner and CLI argument parsing parity.
 - Migration guide documenting environment variables, configuration lookups, and build steps for downstream consumers.
 
+## [1.0.2] - 2025-10-08
+
+### Changed
+- Renamed the context packing service to `context.service.ts` and updated consumers to use the new barrel export.
+
 ## [1.0.1] - 2025-10-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provider-agnostic AI assistant for the command line. Eddie hydrates prompts with
 ## Features
 
 - Multi-provider adapters (OpenAI, Anthropic, Groq-compatible) with streaming support
-- Context packer that pulls files via glob patterns, budgets tokens, and feeds models rich workspace snippets
+- Context service that packs workspace files via glob patterns, budgets tokens, and feeds models rich snippets
 - Tool registry with built-in `bash`, `file_read`, and `file_write` helpers plus confirmation prompts
 - Lifecycle hooks, optional OpenTelemetry spans, and JSONL traces for observability
 - Interactive chat, single-shot prompts, context previews, and automated run mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eddie",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eddie",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
                 "@nestjs/common": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eddie",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "main": "dist/main.js",
     "bin": {
         "eddie": "dist/main.js"

--- a/src/cli/commands/context.command.ts
+++ b/src/cli/commands/context.command.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "../../config/loader";
-import { ContextService } from "../../core/context/packer";
+import { ContextService } from "../../core/context";
 import { TokenizerService } from "../../core/tokenizers/strategy";
 import { LoggerService } from "../../io/logger";
 import type { CliArguments } from "../cli-arguments";

--- a/src/core/context/context.module.ts
+++ b/src/core/context/context.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
 import { IoModule } from "../../io/io.module";
-import { ContextService } from "./packer";
+import { ContextService } from "./context.service";
 
 @Module({
   imports: [IoModule],

--- a/src/core/context/context.service.ts
+++ b/src/core/context/context.service.ts
@@ -15,7 +15,7 @@ export class ContextService {
   constructor(private readonly loggerService: LoggerService) {}
 
   async pack(config: ContextConfig): Promise<PackedContext> {
-    const logger = this.loggerService.getLogger("context:packer");
+    const logger = this.loggerService.getLogger("context:service");
     const baseDir = config.baseDir ?? process.cwd();
     const includePatterns = config.include?.length ? config.include : ["**/*"];
     const excludePatterns = config.exclude ?? [];

--- a/src/core/context/index.ts
+++ b/src/core/context/index.ts
@@ -1,0 +1,2 @@
+export * from "./context.module";
+export * from "./context.service";

--- a/src/core/engine/engine.service.ts
+++ b/src/core/engine/engine.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from "@nestjs/common";
 import path from "path";
 import type { CliRuntimeOptions } from "../../config/types";
 import { ConfigService } from "../../config/loader";
-import { ContextService } from "../context/packer";
+import { ContextService } from "../context/context.service";
 import { ProviderFactory } from "../providers";
 import { ToolRegistryFactory } from "../tools/registry";
 import { builtinTools } from "../tools/builtin";

--- a/test/integration/cli-runner.integration.test.ts
+++ b/test/integration/cli-runner.integration.test.ts
@@ -11,7 +11,7 @@ import { ChatCommand } from "../../src/cli/commands/chat.command";
 import { TraceCommand } from "../../src/cli/commands/trace.command";
 import { EngineService } from "../../src/core/engine";
 import { ConfigService } from "../../src/config/loader";
-import { ContextService } from "../../src/core/context/packer";
+import { ContextService } from "../../src/core/context";
 import { TokenizerService } from "../../src/core/tokenizers/strategy";
 import { LoggerService } from "../../src/io/logger";
 import type { CliCommand } from "../../src/cli/commands/cli-command";

--- a/test/unit/context.test.ts
+++ b/test/unit/context.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Test, type TestingModule } from "@nestjs/testing";
 import fs from "fs/promises";
 import path from "path";
-import { ContextService } from "../../src/core/context/packer";
+import { ContextService } from "../../src/core/context";
 import { LoggerService } from "../../src/io/logger";
 
 const tmpDir = path.join(process.cwd(), "test-temp");


### PR DESCRIPTION
## Summary
- rename the context packer implementation to `context.service.ts` and add a barrel export for downstream consumers
- update imports, documentation, and changelog entries to reflect the renamed service
- bump the package version to 1.0.2 to publish the rename

## Testing
- npm run lint
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e5134ccf548328909856175b18ff3d