### PR TITLE
refactor: modularize hooks and tokenizer services

### DIFF
--- a/docs/adr/0004-hooks-and-tokenizers-module-refactor.md
+++ b/docs/adr/0004-hooks-and-tokenizers-module-refactor.md
@@ -1,0 +1,36 @@
+# ADR 0004: Introduce Hooks and Tokenizer Modules with Barrels
+
+## Status
+
+Accepted
+
+## Context
+
+The hooks loader bundled module resolution helpers with the `HooksService`
+implementation, leaving the service outside Nest's standard `*.service.ts`
+structure. Similarly, the tokenizer logic combined the service with concrete
+strategy implementations in a single file without a corresponding module or
+barrel export. These layouts made it harder to reason about injectable
+providers, complicated future testability, and forced consumers to import from
+deep file paths that expose internal organisation details.
+
+## Decision
+
+We relocated `HooksService` into `src/hooks/hooks.service.ts`, created a
+`HooksModule`, and introduced a `src/hooks/index.ts` barrel so downstream code
+consumes hooks through the directory root. For tokenizers, the strategies now
+live in `strategies.ts` while `TokenizerService` resides in
+`tokenizer.service.ts`, both managed by a new `TokenizersModule` and exported
+via `src/core/tokenizers/index.ts`. Engine consumers now import the modules
+instead of direct file paths, and the engine module re-exports the modules for
+convenience.
+
+## Consequences
+
+- Hooks and tokenizer services follow Nest conventions, improving discoverability
+  and aligning with other modules.
+- Barrel files decouple callers from concrete filenames, reducing churn when the
+  directories evolve.
+- Future extensions—such as additional tokenizer strategies or hook modules—can
+  be registered cleanly via their dedicated modules without revisiting the
+  engine wiring.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eddie",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eddie",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "MIT",
             "dependencies": {
                 "@nestjs/common": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eddie",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "main": "dist/main.js",
     "bin": {
         "eddie": "dist/main.js"

--- a/src/cli/commands/context.command.ts
+++ b/src/cli/commands/context.command.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "../../config";
 import { ContextService } from "../../core/context";
-import { TokenizerService } from "../../core/tokenizers/strategy";
+import { TokenizerService } from "../../core/tokenizers";
 import { LoggerService } from "../../io";
 import type { CliArguments } from "../cli-arguments";
 import { CliOptionsService } from "../cli-options.service";

--- a/src/core/engine/engine.module.ts
+++ b/src/core/engine/engine.module.ts
@@ -5,12 +5,18 @@ import { IoModule } from "../../io";
 import { EngineService } from "./engine.service";
 import { ProviderFactory } from "../providers";
 import { ToolRegistryFactory } from "../tools/registry";
-import { HooksService } from "../../hooks/loader";
-import { TokenizerService } from "../tokenizers/strategy";
+import { HooksModule } from "../../hooks";
+import { TokenizersModule } from "../tokenizers";
 
 @Module({
-  imports: [ConfigModule, ContextModule, IoModule],
-  providers: [EngineService, ProviderFactory, ToolRegistryFactory, HooksService, TokenizerService],
-  exports: [EngineService, ProviderFactory, ToolRegistryFactory, HooksService, TokenizerService],
+  imports: [ConfigModule, ContextModule, IoModule, HooksModule, TokenizersModule],
+  providers: [EngineService, ProviderFactory, ToolRegistryFactory],
+  exports: [
+    EngineService,
+    ProviderFactory,
+    ToolRegistryFactory,
+    HooksModule,
+    TokenizersModule,
+  ],
 })
 export class EngineModule {}

--- a/src/core/engine/engine.service.ts
+++ b/src/core/engine/engine.service.ts
@@ -12,10 +12,10 @@ import {
   LoggerService,
   StreamRendererService,
 } from "../../io";
-import { HooksService } from "../../hooks/loader";
+import { HooksService } from "../../hooks";
 import type { ChatMessage, StreamEvent } from "../types";
 import type { PackedContext } from "../types";
-import { TokenizerService } from "../tokenizers/strategy";
+import { TokenizerService } from "../tokenizers";
 
 export interface EngineOptions extends CliRuntimeOptions {
   history?: ChatMessage[];

--- a/src/core/tokenizers/index.ts
+++ b/src/core/tokenizers/index.ts
@@ -1,0 +1,3 @@
+export * from "./strategies";
+export * from "./tokenizer.service";
+export * from "./tokenizers.module";

--- a/src/core/tokenizers/strategies.ts
+++ b/src/core/tokenizers/strategies.ts
@@ -1,5 +1,3 @@
-import { Injectable } from "@nestjs/common";
-
 export interface TokenizerStrategy {
   countTokens(text: string): number;
 }
@@ -15,14 +13,3 @@ export class AnthropicTokenizer implements TokenizerStrategy {
     return Math.ceil(text.length / 3.7);
   }
 }
-
-@Injectable()
-export class TokenizerService {
-  create(provider: string): TokenizerStrategy {
-    if (provider === "anthropic") {
-      return new AnthropicTokenizer();
-    }
-    return new OpenAITokenizer();
-  }
-}
-

--- a/src/core/tokenizers/tokenizer.service.ts
+++ b/src/core/tokenizers/tokenizer.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "@nestjs/common";
+import {
+  AnthropicTokenizer,
+  OpenAITokenizer,
+  type TokenizerStrategy,
+} from "./strategies";
+
+/**
+ * TokenizerService provides provider-specific token counting strategies.
+ */
+@Injectable()
+export class TokenizerService {
+  create(provider: string): TokenizerStrategy {
+    if (provider === "anthropic") {
+      return new AnthropicTokenizer();
+    }
+    return new OpenAITokenizer();
+  }
+}

--- a/src/core/tokenizers/tokenizers.module.ts
+++ b/src/core/tokenizers/tokenizers.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { TokenizerService } from "./tokenizer.service";
+
+@Module({
+  providers: [TokenizerService],
+  exports: [TokenizerService],
+})
+export class TokenizersModule {}

--- a/src/hooks/hooks.module.ts
+++ b/src/hooks/hooks.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { HooksService } from "./hooks.service";
+
+@Module({
+  providers: [HooksService],
+  exports: [HooksService],
+})
+export class HooksModule {}

--- a/src/hooks/hooks.service.ts
+++ b/src/hooks/hooks.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from "@nestjs/common";
+import type { HooksConfig } from "../config/types";
+import { HookBus } from "./bus";
+import {
+  attachObjectHooks,
+  importHookModule,
+  type HookModule,
+} from "./loader";
+
+/**
+ * HooksService resolves configured hook modules and wires them into the shared
+ * {@link HookBus}. External modules may either register an installer function or
+ * provide a map of event handlers to attach.
+ */
+@Injectable()
+export class HooksService {
+  async load(config?: HooksConfig): Promise<HookBus> {
+    const bus = new HookBus();
+    if (!config?.modules?.length) {
+      return bus;
+    }
+
+    for (const entry of config.modules) {
+      try {
+        const hookModule: HookModule = await importHookModule(
+          entry,
+          config.directory
+        );
+
+        if (typeof hookModule === "function") {
+          await hookModule(bus);
+        } else if (hookModule && typeof hookModule === "object") {
+          attachObjectHooks(bus, hookModule as Record<string, unknown>);
+        }
+      } catch (error) {
+        console.error(`Failed to load hook module "${entry}"`, error);
+      }
+    }
+
+    return bus;
+  }
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,4 @@
+export * from "./bus";
+export * from "./hooks.module";
+export * from "./hooks.service";
+export * from "./loader";

--- a/test/integration/cli-runner.integration.test.ts
+++ b/test/integration/cli-runner.integration.test.ts
@@ -12,7 +12,7 @@ import { TraceCommand } from "../../src/cli/commands/trace.command";
 import { EngineService } from "../../src/core/engine";
 import { ConfigService } from "../../src/config";
 import { ContextService } from "../../src/core/context";
-import { TokenizerService } from "../../src/core/tokenizers/strategy";
+import { TokenizerService } from "../../src/core/tokenizers";
 import { LoggerService } from "../../src/io";
 import type { CliCommand } from "../../src/cli/commands/cli-command";
 import type { CliArguments } from "../../src/cli/cli-arguments";


### PR DESCRIPTION
## Summary
- move the hooks loader logic into a dedicated HooksService within a HooksModule and expose it via a barrel
- split tokenizer strategies from the TokenizerService, add a TokenizersModule, and update engine wiring
- document the restructuring in ADR 0004 and bump the package version to 1.0.4

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e517ad0e8c8328bcf91ebac9c33ce6