### PR TITLE
feat: encapsulate CLI services in module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 - Integration tests covering the Nest-backed command runner and CLI argument parsing parity.
 - Migration guide documenting environment variables, configuration lookups, and build steps for downstream consumers.
 
+## [1.0.5] - 2025-10-09
+
+### Added
+- Introduced a `CliModule` that bundles CLI services and commands behind a barrel export for cleaner imports.
+
+### Changed
+- Updated the root application module and CLI unit tests to resolve services via `CliModule`.
+
 ## [1.0.2] - 2025-10-08
 
 ### Changed

--- a/docs/adr/0005-cli-module-boundary.md
+++ b/docs/adr/0005-cli-module-boundary.md
@@ -1,0 +1,32 @@
+# ADR 0005: Encapsulate CLI Providers in CliModule
+
+## Status
+
+Accepted
+
+## Context
+
+The CLI services and command implementations lived directly in the root
+application module. That arrangement blurred module boundaries, made it harder
+for tests to stand up only the CLI surface, and required downstream callers to
+import individual services from deep file paths. As the CLI grows, the lack of a
+module boundary complicates dependency management and violates Nest's modular
+conventions.
+
+## Decision
+
+We introduced a dedicated `CliModule` under `src/cli/cli.module.ts`. The module
+imports the configuration, context, engine, IO, and tokenizer modules to satisfy
+command dependencies. It provides the CLI option parser, runner, and each
+command, exporting only the `CliRunnerService` for bootstrap code. A barrel file
+at `src/cli/index.ts` now re-exports the module, services, and command types so
+callers can reference the CLI surface without deep relative paths.
+
+## Consequences
+
+- `AppModule` consumes the CLI through the new module import, reducing provider
+  noise and clarifying wiring at the top level.
+- Tests instantiate `CliModule` directly, giving them parity with the runtime
+  dependency graph and simplifying overrides for specific providers.
+- Future CLI additions can register their providers within `CliModule`, keeping
+  the CLI cohesive and preventing regressions when wiring changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eddie",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eddie",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "license": "MIT",
             "dependencies": {
                 "@nestjs/common": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eddie",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "main": "dist/main.js",
     "bin": {
         "eddie": "dist/main.js"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,26 +3,9 @@ import { ConfigModule } from "./config/config.module";
 import { ContextModule } from "./core/context/context.module";
 import { EngineModule } from "./core/engine/engine.module";
 import { IoModule } from "./io/io.module";
-import { CliOptionsService } from "./cli/cli-options.service";
-import { CliParserService } from "./cli/cli-parser.service";
-import { CliRunnerService } from "./cli/cli-runner.service";
-import { AskCommand } from "./cli/commands/ask.command";
-import { RunCommand } from "./cli/commands/run.command";
-import { ContextCommand } from "./cli/commands/context.command";
-import { ChatCommand } from "./cli/commands/chat.command";
-import { TraceCommand } from "./cli/commands/trace.command";
+import { CliModule } from "./cli";
 
 @Module({
-  imports: [ConfigModule, ContextModule, IoModule, EngineModule],
-  providers: [
-    CliOptionsService,
-    CliParserService,
-    CliRunnerService,
-    AskCommand,
-    RunCommand,
-    ContextCommand,
-    ChatCommand,
-    TraceCommand,
-  ],
+  imports: [ConfigModule, ContextModule, IoModule, EngineModule, CliModule],
 })
 export class AppModule {}

--- a/src/cli/cli.module.ts
+++ b/src/cli/cli.module.ts
@@ -1,0 +1,34 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "../config/config.module";
+import { ContextModule } from "../core/context";
+import { EngineModule } from "../core/engine/engine.module";
+import { IoModule } from "../io";
+import { TokenizersModule } from "../core/tokenizers";
+import { CliOptionsService } from "./cli-options.service";
+import { CliParserService } from "./cli-parser.service";
+import { CliRunnerService } from "./cli-runner.service";
+import { AskCommand } from "./commands/ask.command";
+import { ChatCommand } from "./commands/chat.command";
+import { ContextCommand } from "./commands/context.command";
+import { RunCommand } from "./commands/run.command";
+import { TraceCommand } from "./commands/trace.command";
+
+/**
+ * CliModule bundles the CLI surface so commands and supporting services can be
+ * injected wherever a Nest application context is available.
+ */
+@Module({
+  imports: [ConfigModule, ContextModule, EngineModule, IoModule, TokenizersModule],
+  providers: [
+    CliOptionsService,
+    CliParserService,
+    CliRunnerService,
+    AskCommand,
+    RunCommand,
+    ContextCommand,
+    ChatCommand,
+    TraceCommand,
+  ],
+  exports: [CliRunnerService],
+})
+export class CliModule {}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,11 @@
+export { CliModule } from "./cli.module";
+export { CliOptionsService } from "./cli-options.service";
+export { CliParserService, CliParseError } from "./cli-parser.service";
+export { CliRunnerService } from "./cli-runner.service";
+export type { CliArguments } from "./cli-arguments";
+export { AskCommand } from "./commands/ask.command";
+export { RunCommand } from "./commands/run.command";
+export { ContextCommand } from "./commands/context.command";
+export { ChatCommand } from "./commands/chat.command";
+export { TraceCommand } from "./commands/trace.command";
+export type { CliCommand } from "./commands/cli-command";

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
 import "reflect-metadata";
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
-import { CliRunnerService } from "./cli/cli-runner.service";
+import { CliRunnerService } from "./cli";
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.createApplicationContext(AppModule, {

--- a/test/unit/cli-parser.service.test.ts
+++ b/test/unit/cli-parser.service.test.ts
@@ -1,7 +1,16 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Test, type TestingModule } from "@nestjs/testing";
-import { CliParserService, CliParseError } from "../../src/cli/cli-parser.service";
+import {
+  CliModule,
+  CliParserService,
+  CliParseError,
+  AskCommand,
+  RunCommand,
+  ContextCommand,
+  ChatCommand,
+  TraceCommand,
+} from "../../src/cli";
 
 describe("CliParserService", () => {
   let moduleRef: TestingModule;
@@ -9,8 +18,19 @@ describe("CliParserService", () => {
 
   beforeAll(async () => {
     moduleRef = await Test.createTestingModule({
-      providers: [CliParserService],
-    }).compile();
+      imports: [CliModule],
+    })
+      .overrideProvider(AskCommand)
+      .useValue({ name: "ask", run: vi.fn(), aliases: [] })
+      .overrideProvider(RunCommand)
+      .useValue({ name: "run", run: vi.fn(), aliases: [] })
+      .overrideProvider(ContextCommand)
+      .useValue({ name: "context", run: vi.fn(), aliases: [] })
+      .overrideProvider(ChatCommand)
+      .useValue({ name: "chat", run: vi.fn(), aliases: [] })
+      .overrideProvider(TraceCommand)
+      .useValue({ name: "trace", run: vi.fn(), aliases: [] })
+      .compile();
 
     parser = moduleRef.get(CliParserService);
   });


### PR DESCRIPTION
## Summary
- add a dedicated `CliModule` that registers CLI services and command implementations behind a barrel export
- update the application bootstrap and CLI-focused unit tests to resolve providers from the new module
- record the module boundary in a new ADR and bump the package version to 1.0.5

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e51b73cd508328b376c92ed160550c