### PR TITLE
refactor: align provider adapters with NestJS patterns

### DIFF
--- a/src/core/engine/engine.service.ts
+++ b/src/core/engine/engine.service.ts
@@ -3,7 +3,7 @@ import path from "path";
 import type { CliRuntimeOptions } from "../../config/types";
 import { ConfigService } from "../../config";
 import { ContextService } from "../context/context.service";
-import { ProviderFactory } from "../providers/provider-factory.service";
+import { ProviderFactoryService } from "../providers/provider-factory.service";
 import { ToolRegistryFactory, builtinTools } from "../tools";
 import {
   ConfirmService,
@@ -38,7 +38,7 @@ export class EngineService {
   constructor(
     private readonly configService: ConfigService,
     private readonly contextService: ContextService,
-    private readonly providerFactory: ProviderFactory,
+    private readonly providerFactory: ProviderFactoryService,
     private readonly toolRegistryFactory: ToolRegistryFactory,
     private readonly streamRenderer: StreamRendererService,
     private readonly traceWriter: JsonlWriterService,

--- a/src/core/providers/anthropic.ts
+++ b/src/core/providers/anthropic.ts
@@ -1,5 +1,8 @@
+import { Injectable } from "@nestjs/common";
 import { fetch } from "undici";
+import type { ProviderConfig } from "../../config/types";
 import type { ProviderAdapter, StreamEvent, StreamOptions } from "../types";
+import type { ProviderAdapterFactory } from "./provider.tokens";
 
 interface AnthropicConfig {
   baseUrl?: string;
@@ -129,5 +132,19 @@ export class AnthropicAdapter implements ProviderAdapter {
         }
       }
     }
+  }
+}
+
+@Injectable()
+export class AnthropicAdapterFactory implements ProviderAdapterFactory {
+  readonly name = "anthropic";
+
+  create(config: ProviderConfig): ProviderAdapter {
+    const adapterConfig: AnthropicConfig = {
+      baseUrl: typeof config.baseUrl === "string" ? config.baseUrl : undefined,
+      apiKey: typeof config.apiKey === "string" ? config.apiKey : undefined,
+    };
+
+    return new AnthropicAdapter(adapterConfig);
   }
 }

--- a/src/core/providers/index.ts
+++ b/src/core/providers/index.ts
@@ -1,2 +1,3 @@
 export * from "./provider-factory.service";
+export * from "./provider.tokens";
 export * from "./providers.module";

--- a/src/core/providers/openai.ts
+++ b/src/core/providers/openai.ts
@@ -1,5 +1,8 @@
+import { Injectable } from "@nestjs/common";
 import { fetch } from "undici";
+import type { ProviderConfig } from "../../config/types";
 import type { ProviderAdapter, StreamEvent, StreamOptions } from "../types";
+import type { ProviderAdapterFactory } from "./provider.tokens";
 
 interface OpenAIConfig {
   baseUrl?: string;
@@ -124,5 +127,19 @@ export class OpenAIAdapter implements ProviderAdapter {
         }
       }
     }
+  }
+}
+
+@Injectable()
+export class OpenAIAdapterFactory implements ProviderAdapterFactory {
+  readonly name = "openai";
+
+  create(config: ProviderConfig): ProviderAdapter {
+    const adapterConfig: OpenAIConfig = {
+      baseUrl: typeof config.baseUrl === "string" ? config.baseUrl : undefined,
+      apiKey: typeof config.apiKey === "string" ? config.apiKey : undefined,
+    };
+
+    return new OpenAIAdapter(adapterConfig);
   }
 }

--- a/src/core/providers/openai_compatible.ts
+++ b/src/core/providers/openai_compatible.ts
@@ -1,5 +1,8 @@
+import { Injectable } from "@nestjs/common";
 import { fetch } from "undici";
+import type { ProviderConfig } from "../../config/types";
 import type { ProviderAdapter, StreamEvent, StreamOptions } from "../types";
+import type { ProviderAdapterFactory } from "./provider.tokens";
 
 interface OpenAICompatConfig {
   baseUrl?: string;
@@ -82,6 +85,26 @@ export class OpenAICompatibleAdapter implements ProviderAdapter {
         }
       }
     }
+  }
+}
+
+@Injectable()
+export class OpenAICompatibleAdapterFactory
+  implements ProviderAdapterFactory
+{
+  readonly name = "openai_compatible";
+
+  create(config: ProviderConfig): ProviderAdapter {
+    const adapterConfig: OpenAICompatConfig = {
+      baseUrl: typeof config.baseUrl === "string" ? config.baseUrl : undefined,
+      apiKey: typeof config.apiKey === "string" ? config.apiKey : undefined,
+      headers:
+        config.headers && typeof config.headers === "object"
+          ? (config.headers as Record<string, string>)
+          : undefined,
+    };
+
+    return new OpenAICompatibleAdapter(adapterConfig);
   }
 }
 

--- a/src/core/providers/provider-factory.service.ts
+++ b/src/core/providers/provider-factory.service.ts
@@ -1,34 +1,41 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import type { ProviderConfig } from "../../config/types";
 import type { ProviderAdapter } from "../types";
-import { AnthropicAdapter } from "./anthropic";
-import { OpenAIAdapter } from "./openai";
-import { OpenAICompatibleAdapter } from "./openai_compatible";
+import {
+  PROVIDER_ADAPTER_FACTORIES,
+  ProviderAdapterFactory,
+} from "./provider.tokens";
 
 /**
- * ProviderFactory creates a concrete provider adapter for the configured
+ * ProviderFactoryService creates a concrete provider adapter for the configured
  * provider name. It centralises adapter construction so dependency injection
  * consumers can request a single factory regardless of the underlying API.
  */
 @Injectable()
-export class ProviderFactory {
+export class ProviderFactoryService {
+  constructor(
+    @Inject(PROVIDER_ADAPTER_FACTORIES)
+    private readonly factories: ProviderAdapterFactory[]
+  ) {}
+
   create(config: ProviderConfig): ProviderAdapter {
-    switch (config.name) {
-      case "openai":
-        return new OpenAIAdapter(config);
-      case "anthropic":
-        return new AnthropicAdapter(config);
-      case "openai_compatible":
-        return new OpenAICompatibleAdapter(config);
-      case "noop":
-        return {
-          name: "noop",
-          async *stream() {
-            yield { type: "error", message: "No provider configured" } as const;
-          },
-        };
-      default:
-        throw new Error(`Unknown provider: ${config.name}`);
+    if (config.name === "noop") {
+      return {
+        name: "noop",
+        async *stream() {
+          yield { type: "error", message: "No provider configured" } as const;
+        },
+      };
     }
+
+    const factory = this.factories.find(
+      (candidate) => candidate.name === config.name
+    );
+
+    if (!factory) {
+      throw new Error(`Unknown provider: ${config.name}`);
+    }
+
+    return factory.create(config);
   }
 }

--- a/src/core/providers/provider.tokens.ts
+++ b/src/core/providers/provider.tokens.ts
@@ -1,0 +1,11 @@
+import type { ProviderConfig } from "../../config/types";
+import type { ProviderAdapter } from "../types";
+
+export interface ProviderAdapterFactory {
+  readonly name: string;
+  create(config: ProviderConfig): ProviderAdapter;
+}
+
+export const PROVIDER_ADAPTER_FACTORIES = Symbol(
+  "PROVIDER_ADAPTER_FACTORIES"
+);

--- a/src/core/providers/providers.module.ts
+++ b/src/core/providers/providers.module.ts
@@ -1,12 +1,35 @@
 import { Module } from "@nestjs/common";
-import { ProviderFactory } from "./provider-factory.service";
+import { AnthropicAdapterFactory } from "./anthropic";
+import { OpenAIAdapterFactory } from "./openai";
+import { OpenAICompatibleAdapterFactory } from "./openai_compatible";
+import { ProviderFactoryService } from "./provider-factory.service";
+import { PROVIDER_ADAPTER_FACTORIES } from "./provider.tokens";
 
 /**
- * ProvidersModule exposes the ProviderFactory so other modules can inject it
- * without depending on the providers directory structure.
+ * ProvidersModule exposes the ProviderFactoryService so other modules can
+ * resolve provider adapters without depending on the providers directory
+ * structure.
  */
 @Module({
-  providers: [ProviderFactory],
-  exports: [ProviderFactory],
+  providers: [
+    AnthropicAdapterFactory,
+    OpenAIAdapterFactory,
+    OpenAICompatibleAdapterFactory,
+    {
+      provide: PROVIDER_ADAPTER_FACTORIES,
+      useFactory: (
+        anthropic: AnthropicAdapterFactory,
+        openai: OpenAIAdapterFactory,
+        openaiCompatible: OpenAICompatibleAdapterFactory
+      ) => [anthropic, openai, openaiCompatible],
+      inject: [
+        AnthropicAdapterFactory,
+        OpenAIAdapterFactory,
+        OpenAICompatibleAdapterFactory,
+      ],
+    },
+    ProviderFactoryService,
+  ],
+  exports: [ProviderFactoryService],
 })
 export class ProvidersModule {}


### PR DESCRIPTION
## Summary
- introduce dedicated adapter factories registered via a shared injection token
- expose the provider factory service through the ProvidersModule using NestJS DI conventions
- update the engine to consume the new ProviderFactoryService implementation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e53ef723688328a494a948b508fbd4