### PR TITLE
fix: allow hook bus to handle many listeners

### DIFF
--- a/src/hooks/hook-bus.service.ts
+++ b/src/hooks/hook-bus.service.ts
@@ -9,9 +9,21 @@ import type {
 } from "./types";
 import { isHookBlockResponse } from "./types";
 
+/**
+ * Hook event bus capable of fanning out to an arbitrary number of listeners.
+ *
+ * The default Node.js `EventEmitter` warns after 10 listeners which is too low
+ * for Eddie's hook system. We explicitly disable that cap so integrations can
+ * register freely without triggering warnings.
+ */
 @Injectable()
 export class HookBus extends EventEmitter {
   private readonly logger = new Logger(HookBus.name);
+
+  constructor() {
+    super();
+    this.setMaxListeners(0);
+  }
 
   async emitAsync<K extends HookEventName>(
     event: K,

--- a/test/unit/hooks/hook-bus.service.test.ts
+++ b/test/unit/hooks/hook-bus.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { HookBus, blockHook } from "../../../src/hooks";
 import type { HookBlockResponse } from "../../../src/hooks";
 
@@ -72,5 +72,26 @@ describe("HookBus", () => {
     expect(result.results).toHaveLength(0);
     expect(result.error).toBeInstanceOf(Error);
     expect(calls).toEqual(["first"]);
+  });
+
+  it("supports more than ten listeners without warnings", async () => {
+    const bus = new HookBus();
+    const warningSpy = vi.spyOn(process, "emitWarning");
+
+    const events: number[] = [];
+    for (let i = 0; i < 11; i += 1) {
+      bus.on("beforeContextPack", () => {
+        events.push(i);
+      });
+    }
+
+    await bus.emitAsync("beforeContextPack", {
+      config: {} as any,
+      options: {} as any,
+    });
+
+    expect(events).toHaveLength(11);
+    expect(warningSpy).not.toHaveBeenCalled();
+    warningSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- add a HookBus constructor that disables the default EventEmitter listener cap
- document the unlimited listener intent in the HookBus JSDoc
- add a regression test ensuring more than ten listeners can be registered without warnings

## Testing
- npx vitest run test/unit/hooks/hook-bus.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e565e476388328995250fc3b40b3a4