### PR TITLE
style: reformat src/core/types.ts

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,96 +2,96 @@ import { env as ProcessEnv } from "process";
 export type Role = "system" | "user" | "assistant" | "tool";
 
 export interface ChatMessage {
-    role: Role;
-    content: string;
-    name?: string;
-    tool_call_id?: string;
+  role: Role;
+  content: string;
+  name?: string;
+  tool_call_id?: string;
 }
 
 export interface ToolCallArguments {
-    [ key: string ]: unknown;
+  [key: string]: unknown;
 }
 
 export interface ToolSchema {
-    type: "function";
-    name: string;
-    description?: string;
-    parameters: Record<string, unknown>;
+  type: "function";
+  name: string;
+  description?: string;
+  parameters: Record<string, unknown>;
 }
 
 export type StreamEvent =
-    | {
-        type: "delta";
-        text: string;
-        id?: string;
+  | {
+      type: "delta";
+      text: string;
+      id?: string;
     }
-    | {
-        type: "tool_call";
-        name: string;
-        arguments: ToolCallArguments;
-        id?: string;
-        raw?: unknown;
+  | {
+      type: "tool_call";
+      name: string;
+      arguments: ToolCallArguments;
+      id?: string;
+      raw?: unknown;
     }
-    | {
-        type: "tool_result";
-        name: string;
-        result: unknown;
-        id?: string;
+  | {
+      type: "tool_result";
+      name: string;
+      result: unknown;
+      id?: string;
     }
-    | {
-        type: "error";
-        message: string;
-        cause?: unknown;
+  | {
+      type: "error";
+      message: string;
+      cause?: unknown;
     }
-    | {
-        type: "notification";
-        payload: unknown;
-        metadata?: Record<string, unknown>;
+  | {
+      type: "notification";
+      payload: unknown;
+      metadata?: Record<string, unknown>;
     }
-    | {
-        type: "end";
-        reason?: string;
-        usage?: Record<string, unknown>;
+  | {
+      type: "end";
+      reason?: string;
+      usage?: Record<string, unknown>;
     };
 
 export interface StreamOptions {
-    model: string;
-    messages: ChatMessage[];
-    tools?: ToolSchema[];
-    responseFormat?: Record<string, unknown>;
-    metadata?: Record<string, unknown>;
+  model: string;
+  messages: ChatMessage[];
+  tools?: ToolSchema[];
+  responseFormat?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ProviderAdapter {
-    readonly name: string;
-    stream(options: StreamOptions): AsyncIterable<StreamEvent>;
+  readonly name: string;
+  stream(options: StreamOptions): AsyncIterable<StreamEvent>;
 }
 
 export interface PackedFile {
-    path: string;
-    bytes: number;
-    content: string;
+  path: string;
+  bytes: number;
+  content: string;
 }
 
 export interface PackedContext {
-    files: PackedFile[];
-    totalBytes: number;
-    text: string;
+  files: PackedFile[];
+  totalBytes: number;
+  text: string;
 }
 
 export interface ToolExecutionContext {
-    cwd: string;
-    confirm(message: string): Promise<boolean>;
-    env: typeof ProcessEnv;
+  cwd: string;
+  confirm(message: string): Promise<boolean>;
+  env: typeof ProcessEnv;
 }
 
 export interface ToolDefinition {
-    name: string;
-    description?: string;
-    jsonSchema: Record<string, unknown>;
-    validate?: (data: unknown) => boolean;
-    handler(
-        args: ToolCallArguments,
-        ctx: ToolExecutionContext
-    ): Promise<{ content: string; metadata?: Record<string, unknown>; }>;
+  name: string;
+  description?: string;
+  jsonSchema: Record<string, unknown>;
+  validate?: (data: unknown) => boolean;
+  handler(
+    args: ToolCallArguments,
+    ctx: ToolExecutionContext,
+  ): Promise<{ content: string; metadata?: Record<string, unknown> }>;
 }


### PR DESCRIPTION
## Summary
- reformat `src/core/types.ts` to align with repository Prettier/ESLint conventions

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e566e9325c83289af1dc89b5277822