### PR TITLE
fix: type otel record helper

### DIFF
--- a/src/hooks/otel.ts
+++ b/src/hooks/otel.ts
@@ -1,11 +1,13 @@
-import { context, trace } from "@opentelemetry/api";
+import { context, trace, type SpanAttributeValue } from "@opentelemetry/api";
 
 export function startSpan(name: string) {
   const tracer = trace.getTracer("eddie-cli");
   const span = tracer.startSpan(name);
   return {
     end: () => span.end(),
-    record: (key: string, value: unknown) => span.setAttribute(key, value as never),
+    record: (key: string, value: SpanAttributeValue) => {
+      span.setAttribute(key, value);
+    },
     get context() {
       return context.active();
     },

--- a/test/unit/hooks/otel.test.ts
+++ b/test/unit/hooks/otel.test.ts
@@ -1,0 +1,34 @@
+import { trace, type Tracer } from "@opentelemetry/api";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startSpan } from "../../../src/hooks/otel";
+
+describe("otel hook", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("records attributes for all supported types", () => {
+    const setAttribute = vi.fn();
+    const end = vi.fn();
+    const span = { setAttribute, end };
+    const startSpanSpy = vi.fn(() => span);
+
+    vi.spyOn(trace, "getTracer").mockReturnValue({
+      startSpan: startSpanSpy,
+    } as unknown as Tracer);
+
+    const { record } = startSpan("test");
+
+    record("string", "value");
+    record("number", 42);
+    record("boolean", true);
+    record("array", ["a", "b"]);
+
+    expect(setAttribute).toHaveBeenNthCalledWith(1, "string", "value");
+    expect(setAttribute).toHaveBeenNthCalledWith(2, "number", 42);
+    expect(setAttribute).toHaveBeenNthCalledWith(3, "boolean", true);
+    expect(setAttribute).toHaveBeenNthCalledWith(4, "array", ["a", "b"]);
+    expect(end).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- type the otel hook record helper with SpanAttributeValue from the OpenTelemetry API
- cover recording various attribute types with a new otel hook unit test

## Testing
- npx vitest run test/unit/hooks/otel.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e566c7cf9483288462cd88daf4f4fd