### PR TITLE
feat: standardize hook event naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,34 @@ Every payload includes the agent's prompt, context summary, history length, and
 sanitised metadata so downstream systems can observe full hierarchies without
 needing internal Eddie classes.
 
+### Hook event naming
+
+Hook identifiers are now canonicalised as camelCase strings. Import
+`HOOK_EVENTS` from the published `eddie/hooks` entrypoint (or directly from
+`src/hooks` when working inside this repository) to avoid typos and stay
+aligned with future additions:
+
+```ts
+import { HOOK_EVENTS } from "eddie/hooks";
+
+export default {
+  [HOOK_EVENTS.sessionStart]: (payload) => {
+    // session metadata + runtime config
+  },
+  [HOOK_EVENTS.userPromptSubmit]: (payload) => {
+    // prompt text and history length
+  },
+  [HOOK_EVENTS.afterAgentComplete]: (payload) => {
+    // agent transcript and iteration counts
+  },
+};
+```
+
+The existing PascalCase spellings (`SessionStart`, `PreToolUse`, `Stop`, etc.)
+are still accepted for the current release and emit a deprecation warning when
+loaded. They will be removed after the next minor release, so update custom
+hook modules to the camelCase variants soon to avoid interruptions.
+
 ## Testing
 
 ```bash

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,6 +1,27 @@
 import type { ChatMessage, PackedContext, StreamEvent } from "../core/types";
 import type { CliRuntimeOptions, EddieConfig } from "../config/types";
 
+export const HOOK_EVENTS = {
+  beforeContextPack: "beforeContextPack",
+  afterContextPack: "afterContextPack",
+  sessionStart: "sessionStart",
+  userPromptSubmit: "userPromptSubmit",
+  sessionEnd: "sessionEnd",
+  beforeAgentStart: "beforeAgentStart",
+  afterAgentComplete: "afterAgentComplete",
+  onAgentError: "onAgentError",
+  beforeModelCall: "beforeModelCall",
+  preCompact: "preCompact",
+  preToolUse: "preToolUse",
+  postToolUse: "postToolUse",
+  notification: "notification",
+  onError: "onError",
+  stop: "stop",
+  subagentStop: "subagentStop",
+} as const;
+
+export type HookEventName = (typeof HOOK_EVENTS)[keyof typeof HOOK_EVENTS];
+
 export interface SessionMetadata {
   id: string;
   startedAt: string;
@@ -97,26 +118,27 @@ export interface AgentNotificationPayload extends AgentLifecyclePayload {
   event: Extract<StreamEvent, { type: "notification" }>;
 }
 
-export interface HookEventMap {
-  beforeContextPack: { config: EddieConfig; options: CliRuntimeOptions };
-  afterContextPack: { context: PackedContext };
-  SessionStart: SessionStartPayload;
-  UserPromptSubmit: UserPromptSubmitPayload;
-  SessionEnd: SessionEndPayload;
-  beforeAgentStart: AgentLifecyclePayload;
-  afterAgentComplete: AgentCompletionPayload;
-  onAgentError: AgentErrorPayload;
-  beforeModelCall: AgentIterationPayload;
-  PreCompact: AgentTranscriptCompactionPayload;
-  PreToolUse: AgentToolCallPayload;
-  PostToolUse: AgentToolResultPayload;
-  Notification: AgentNotificationPayload;
-  onError: AgentStreamErrorPayload;
-  Stop: AgentIterationPayload;
-  SubagentStop: AgentLifecyclePayload;
-}
-
-export type HookEventName = keyof HookEventMap;
+export type HookEventMap = {
+  [HOOK_EVENTS.beforeContextPack]: {
+    config: EddieConfig;
+    options: CliRuntimeOptions;
+  };
+  [HOOK_EVENTS.afterContextPack]: { context: PackedContext };
+  [HOOK_EVENTS.sessionStart]: SessionStartPayload;
+  [HOOK_EVENTS.userPromptSubmit]: UserPromptSubmitPayload;
+  [HOOK_EVENTS.sessionEnd]: SessionEndPayload;
+  [HOOK_EVENTS.beforeAgentStart]: AgentLifecyclePayload;
+  [HOOK_EVENTS.afterAgentComplete]: AgentCompletionPayload;
+  [HOOK_EVENTS.onAgentError]: AgentErrorPayload;
+  [HOOK_EVENTS.beforeModelCall]: AgentIterationPayload;
+  [HOOK_EVENTS.preCompact]: AgentTranscriptCompactionPayload;
+  [HOOK_EVENTS.preToolUse]: AgentToolCallPayload;
+  [HOOK_EVENTS.postToolUse]: AgentToolResultPayload;
+  [HOOK_EVENTS.notification]: AgentNotificationPayload;
+  [HOOK_EVENTS.onError]: AgentStreamErrorPayload;
+  [HOOK_EVENTS.stop]: AgentIterationPayload;
+  [HOOK_EVENTS.subagentStop]: AgentLifecyclePayload;
+};
 
 export type HookListener<K extends HookEventName> = (
   payload: HookEventMap[K]
@@ -154,24 +176,7 @@ export type HookEventHandlers = {
   [K in HookEventName]?: HookListener<K>;
 };
 
-export const hookEventNames: HookEventName[] = [
-  "beforeContextPack",
-  "afterContextPack",
-  "SessionStart",
-  "UserPromptSubmit",
-  "SessionEnd",
-  "beforeAgentStart",
-  "afterAgentComplete",
-  "onAgentError",
-  "beforeModelCall",
-  "PreCompact",
-  "PreToolUse",
-  "PostToolUse",
-  "Notification",
-  "onError",
-  "Stop",
-  "SubagentStop",
-];
+export const hookEventNames = Object.values(HOOK_EVENTS) as HookEventName[];
 
 export function isHookEventName(value: string): value is HookEventName {
   return (hookEventNames as readonly string[]).includes(value);

--- a/test/unit/hooks/hook-bus.service.test.ts
+++ b/test/unit/hooks/hook-bus.service.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi } from "vitest";
-import { HookBus, blockHook } from "../../../src/hooks";
+import { HOOK_EVENTS, HookBus, blockHook } from "../../../src/hooks";
 import type { HookBlockResponse } from "../../../src/hooks";
 
 describe("HookBus", () => {
   it("returns listener results in registration order", async () => {
     const bus = new HookBus();
 
-    bus.on("beforeContextPack", () => "first");
-    bus.on("beforeContextPack", async () => "second");
+    bus.on(HOOK_EVENTS.beforeContextPack, () => "first");
+    bus.on(HOOK_EVENTS.beforeContextPack, async () => "second");
 
-    const result = await bus.emitAsync("beforeContextPack", {
+    const result = await bus.emitAsync(HOOK_EVENTS.beforeContextPack, {
       config: {} as any,
       options: {} as any,
     });
@@ -23,12 +23,12 @@ describe("HookBus", () => {
     const bus = new HookBus();
     const observed: HookBlockResponse[] = [];
 
-    bus.on("beforeModelCall", () => blockHook("not allowed"));
-    bus.on("beforeModelCall", () => {
+    bus.on(HOOK_EVENTS.beforeModelCall, () => blockHook("not allowed"));
+    bus.on(HOOK_EVENTS.beforeModelCall, () => {
       throw new Error("should not run");
     });
 
-    const result = await bus.emitAsync("beforeModelCall", {
+    const result = await bus.emitAsync(HOOK_EVENTS.beforeModelCall, {
       metadata: { id: "agent", parentId: undefined, depth: 0, isRoot: true, systemPrompt: "", tools: [] },
       prompt: "prompt",
       context: { totalBytes: 0, fileCount: 0 },
@@ -51,16 +51,16 @@ describe("HookBus", () => {
     const bus = new HookBus();
     const calls: string[] = [];
 
-    bus.on("Stop", () => {
+    bus.on(HOOK_EVENTS.stop, () => {
       calls.push("first");
       throw new Error("boom");
     });
-    bus.on("Stop", () => {
+    bus.on(HOOK_EVENTS.stop, () => {
       calls.push("second");
       return undefined;
     });
 
-    const result = await bus.emitAsync("Stop", {
+    const result = await bus.emitAsync(HOOK_EVENTS.stop, {
       metadata: { id: "agent", parentId: undefined, depth: 0, isRoot: true, systemPrompt: "", tools: [] },
       prompt: "",
       context: { totalBytes: 0, fileCount: 0 },
@@ -80,12 +80,12 @@ describe("HookBus", () => {
 
     const events: number[] = [];
     for (let i = 0; i < 11; i += 1) {
-      bus.on("beforeContextPack", () => {
+      bus.on(HOOK_EVENTS.beforeContextPack, () => {
         events.push(i);
       });
     }
 
-    await bus.emitAsync("beforeContextPack", {
+    await bus.emitAsync(HOOK_EVENTS.beforeContextPack, {
       config: {} as any,
       options: {} as any,
     });


### PR DESCRIPTION
## Summary
- add a central `HOOK_EVENTS` map so hook names and derived types stay in sync
- emit camelCase hook events throughout the engine/orchestrator and update tests and docs
- translate legacy PascalCase hook registrations with a deprecation warning for existing modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e56a1fc240832885a02f1b13c89a6e