### PR TITLE
docs: document hook lifecycles and payloads

### DIFF
--- a/src/core/agents/agent-orchestrator.service.ts
+++ b/src/core/agents/agent-orchestrator.service.ts
@@ -139,6 +139,15 @@ export class AgentOrchestratorService {
     return result;
   }
 
+  /**
+   * Drives a single agent invocation through its lifecycle, emitting
+   * `beforeAgentStart` once, then for each iteration optionally `preCompact`,
+   * followed by `beforeModelCall`. Tool calls trigger the
+   * `preToolUse`/`postToolUse` pair (or `onAgentError` on failure), stream
+   * anomalies emit `notification`, `onError`, and `onAgentError`, and each
+   * iteration culminates with `stop`. When the agent finishes cleanly,
+   * `afterAgentComplete` fires, and non-root agents also raise `subagentStop`.
+   */
   private async executeInvocation(invocation: AgentInvocation): Promise<void> {
     const runtime = this.runtimeMap.get(invocation);
     if (!runtime) {

--- a/src/core/engine/engine.service.ts
+++ b/src/core/engine/engine.service.ts
@@ -57,6 +57,13 @@ export class EngineService {
     private readonly agentOrchestrator: AgentOrchestratorService
   ) {}
 
+  /**
+   * Executes a single CLI run, emitting hooks in the order
+   * `sessionStart` → `beforeContextPack` → `afterContextPack` →
+   * `userPromptSubmit` before delegating to the agent orchestrator. Once the
+   * agent tree finishes, a terminal `sessionEnd` hook is dispatched with the
+   * aggregated result or failure context.
+   */
   async run(prompt: string, options: EngineOptions = {}): Promise<EngineResult> {
     const runStartedAt = Date.now();
     const sessionId = randomUUID();


### PR DESCRIPTION
## Summary
- document hook payload interfaces with lifecycle context and field descriptions
- add lifecycle overview comments for hook event constants and map definitions
- reference hook sequencing in engine and agent orchestrator implementations

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e56cc0c3988328958ac71644bc9be5