### PR TITLE
refactor: introduce agent invocation factory

### DIFF
--- a/src/core/agents/agent-invocation.factory.ts
+++ b/src/core/agents/agent-invocation.factory.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+import type { ToolRegistryFactory } from "../tools";
+import type { AgentDefinition } from "./agent-definition";
+import { AgentInvocation, type AgentInvocationOptions } from "./agent-invocation";
+
+@Injectable()
+export class AgentInvocationFactory {
+  constructor(
+    private readonly toolRegistryFactory: ToolRegistryFactory
+  ) {}
+
+  create(
+    definition: AgentDefinition,
+    options: AgentInvocationOptions,
+    parent?: AgentInvocation
+  ): AgentInvocation {
+    return new AgentInvocation(
+      definition,
+      options,
+      this.toolRegistryFactory,
+      parent
+    );
+  }
+}

--- a/src/core/agents/agent-orchestrator.service.ts
+++ b/src/core/agents/agent-orchestrator.service.ts
@@ -12,13 +12,13 @@ import type {
   HookEventName,
 } from "../../hooks";
 import type { ProviderAdapter } from "../types";
-import { ToolRegistryFactory } from "../tools";
 import type { AgentDefinition } from "./agent-definition";
 import {
   AgentInvocation,
   type AgentInvocationOptions,
   type AgentSpawnHandler,
 } from "./agent-invocation";
+import { AgentInvocationFactory } from "./agent-invocation.factory";
 
 interface AgentTraceEvent {
   phase: string;
@@ -64,7 +64,7 @@ export class AgentOrchestratorService {
   private readonly runtimeMap = new WeakMap<AgentInvocation, AgentRuntimeOptions>();
 
   constructor(
-    private readonly toolRegistryFactory: ToolRegistryFactory,
+    private readonly agentInvocationFactory: AgentInvocationFactory,
     private readonly streamRenderer: StreamRendererService,
     private readonly traceWriter: JsonlWriterService
   ) {}
@@ -73,14 +73,13 @@ export class AgentOrchestratorService {
     request: AgentRunRequest,
     runtime: AgentRuntimeOptions
   ): Promise<AgentInvocation> {
-    const invocation = new AgentInvocation(
+    const invocation = this.agentInvocationFactory.create(
       request.definition,
       {
         prompt: request.prompt,
         context: request.context,
         history: request.history,
       },
-      this.toolRegistryFactory,
       request.parent
     );
 
@@ -109,10 +108,9 @@ export class AgentOrchestratorService {
       );
     }
 
-    const invocation = new AgentInvocation(
+    const invocation = this.agentInvocationFactory.create(
       definition,
       options,
-      this.toolRegistryFactory,
       parent
     );
 

--- a/src/core/agents/index.ts
+++ b/src/core/agents/index.ts
@@ -1,3 +1,4 @@
 export * from "./agent-definition";
+export * from "./agent-invocation.factory";
 export * from "./agent-invocation";
 export * from "./agent-orchestrator.service";

--- a/src/core/engine/engine.module.ts
+++ b/src/core/engine/engine.module.ts
@@ -7,7 +7,7 @@ import { ProvidersModule } from "../providers/providers.module";
 import { TokenizersModule } from "../tokenizers";
 import { EngineService } from "./engine.service";
 import { ToolsModule } from "../tools";
-import { AgentOrchestratorService } from "../agents";
+import { AgentInvocationFactory, AgentOrchestratorService } from "../agents";
 
 @Module({
   imports: [
@@ -19,7 +19,7 @@ import { AgentOrchestratorService } from "../agents";
     TokenizersModule,
     ToolsModule,
   ],
-  providers: [EngineService, AgentOrchestratorService],
+  providers: [EngineService, AgentInvocationFactory, AgentOrchestratorService],
   exports: [
     EngineService,
     AgentOrchestratorService,


### PR DESCRIPTION
## Summary
- add an injectable `AgentInvocationFactory` that creates `AgentInvocation` instances with the existing `ToolRegistryFactory`
- register the factory with the agents module exports and engine module providers
- inject the factory into `AgentOrchestratorService` and update its unit tests to spy on the factory

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5719b04348328a0acdf853f85b057