### PR TITLE
refactor: inject tokenizer strategies

### DIFF
--- a/src/core/tokenizers/strategies.ts
+++ b/src/core/tokenizers/strategies.ts
@@ -1,13 +1,17 @@
+import { Injectable, Scope } from "@nestjs/common";
+
 export interface TokenizerStrategy {
   countTokens(text: string): number;
 }
 
+@Injectable({ scope: Scope.TRANSIENT })
 export class OpenAITokenizer implements TokenizerStrategy {
   countTokens(text: string): number {
     return Math.ceil(text.length / 4);
   }
 }
 
+@Injectable({ scope: Scope.TRANSIENT })
 export class AnthropicTokenizer implements TokenizerStrategy {
   countTokens(text: string): number {
     return Math.ceil(text.length / 3.7);

--- a/src/core/tokenizers/tokenizers.module.ts
+++ b/src/core/tokenizers/tokenizers.module.ts
@@ -1,8 +1,34 @@
 import { Module } from "@nestjs/common";
-import { TokenizerService } from "./tokenizer.service";
+import {
+  TokenizerService,
+  TOKENIZER_STRATEGIES,
+  type TokenizerStrategyRegistry,
+} from "./tokenizer.service";
+import { AnthropicTokenizer, OpenAITokenizer } from "./strategies";
 
 @Module({
-  providers: [TokenizerService],
-  exports: [TokenizerService],
+  providers: [
+    OpenAITokenizer,
+    AnthropicTokenizer,
+    {
+      provide: TOKENIZER_STRATEGIES,
+      useFactory: (
+        openai: OpenAITokenizer,
+        anthropic: AnthropicTokenizer
+      ): TokenizerStrategyRegistry => ({
+        openai,
+        "openai-compatible": openai,
+        anthropic,
+      }),
+      inject: [OpenAITokenizer, AnthropicTokenizer],
+    },
+    TokenizerService,
+  ],
+  exports: [
+    TokenizerService,
+    OpenAITokenizer,
+    AnthropicTokenizer,
+    TOKENIZER_STRATEGIES,
+  ],
 })
 export class TokenizersModule {}


### PR DESCRIPTION
## Summary
- make the OpenAI and Anthropic tokenizers transient Nest providers
- register tokenizer strategy providers in the TokenizersModule and expose a strategy registry
- update TokenizerService to resolve strategies from dependency injection rather than constructing them directly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5754d0eac8328a62ac00d30e4a0d9