### PR TITLE
fix: resolve file read tool paths from context

### DIFF
--- a/src/core/tools/builtin/file_read.ts
+++ b/src/core/tools/builtin/file_read.ts
@@ -14,9 +14,9 @@ export const fileReadTool: ToolDefinition = {
     required: ["path"],
     additionalProperties: false,
   },
-  async handler(args) {
+  async handler(args, ctx) {
     const relPath = String(args.path ?? "");
-    const absolute = path.resolve(process.cwd(), relPath);
+    const absolute = path.resolve(ctx.cwd, relPath);
     const content = await fs.readFile(absolute, "utf-8");
     const maxBytes = args.maxBytes ? Number(args.maxBytes) : undefined;
     const slice =

--- a/test/unit/core/tools/file_read.tool.test.ts
+++ b/test/unit/core/tools/file_read.tool.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { fileReadTool } from "../../../../src/core/tools/builtin/file_read";
+
+const tempDirs: string[] = [];
+
+describe("fileReadTool", () => {
+  afterAll(async () => {
+    await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("reads files relative to the provided context cwd", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eddie-file-read-"));
+    tempDirs.push(tmpDir);
+
+    const fileName = "example.txt";
+    await fs.writeFile(path.join(tmpDir, fileName), "hello from ctx", "utf-8");
+
+    const result = await fileReadTool.handler(
+      { path: fileName },
+      {
+        cwd: tmpDir,
+        confirm: vi.fn(),
+        env: process.env,
+      },
+    );
+
+    expect(result.content).toBe("hello from ctx");
+  });
+
+  it("truncates content when maxBytes is provided", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eddie-file-read-"));
+    tempDirs.push(tmpDir);
+
+    const fileName = "truncate.txt";
+    await fs.writeFile(path.join(tmpDir, fileName), "abcdef", "utf-8");
+
+    const result = await fileReadTool.handler(
+      { path: fileName, maxBytes: 3 },
+      {
+        cwd: tmpDir,
+        confirm: vi.fn(),
+        env: process.env,
+      },
+    );
+
+    expect(result.content).toBe("abc");
+  });
+});


### PR DESCRIPTION
## Summary
- update the file_read tool to resolve file paths against the tool execution context
- add unit tests verifying custom cwd support and maxBytes truncation behaviour

## Testing
- npx vitest run test/unit/core/tools/file_read.tool.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5799c6b2c832890d1862f821ac8d1