### PR TITLE
fix: aggregate tool call deltas in openai compatible adapter

### DIFF
--- a/test/unit/core/providers/openai_compatible.adapter.test.ts
+++ b/test/unit/core/providers/openai_compatible.adapter.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { OpenAICompatibleAdapter } from "../../../../src/core/providers/openai_compatible";
+
+const encoder = new TextEncoder();
+const mocks = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+vi.mock("undici", () => ({
+  fetch: mocks.fetchMock,
+}));
+
+describe("OpenAICompatibleAdapter", () => {
+
+  beforeEach(() => {
+    mocks.fetchMock.mockReset();
+  });
+
+  it("emits tool_call events for aggregated tool call fragments", async () => {
+    const chunks = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_123",
+                  function: { name: "test_tool", arguments: '{"foo":' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  function: { arguments: '"bar"}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+    ];
+
+    const stream = chunks
+      .map((chunk) => `data: ${JSON.stringify(chunk)}\n`)
+      .concat("data: [DONE]\n");
+
+    mocks.fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      body: {
+        getReader() {
+          let index = 0;
+          return {
+            read: async () => {
+              if (index >= stream.length) {
+                return { done: true, value: undefined };
+              }
+              const value = encoder.encode(stream[index++] as string);
+              return { done: false, value };
+            },
+          };
+        },
+      },
+    });
+
+    const adapter = new OpenAICompatibleAdapter({});
+
+    const events: unknown[] = [];
+    const streamIterator = adapter.stream({
+      model: "test-model",
+      messages: [],
+    });
+
+    for await (const event of streamIterator) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(2);
+    const [toolCall, endEvent] = events as [
+      { type: string; id?: string; name?: string; arguments?: unknown; raw?: unknown },
+      { type: string }
+    ];
+
+    expect(toolCall).toMatchObject({
+      type: "tool_call",
+      id: "call_123",
+      name: "test_tool",
+      arguments: { foo: "bar" },
+    });
+    expect(toolCall.raw).toBe('{"foo":"bar"}');
+    expect(endEvent.type).toBe("end");
+  });
+});
+


### PR DESCRIPTION
## Summary
- accumulate tool call fragments from OpenAI-compatible streaming responses and emit tool_call events when the finish reason is tool_calls
- keep the stream open long enough to flush the final [DONE] marker so the orchestrator can schedule tool execution
- add a unit test that covers tool call aggregation for the OpenAI-compatible adapter

## Testing
- npm run test -- openai_compatible.adapter.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e579ab79308328b9fbee8a615bc228