### PR TITLE
feat: validate structured tool outputs

### DIFF
--- a/src/core/agents/agent-orchestrator.service.ts
+++ b/src/core/agents/agent-orchestrator.service.ts
@@ -299,11 +299,31 @@ export class AgentOrchestratorService {
                 env: process.env,
               });
 
+              this.streamRenderer.render({
+                type: "tool_result",
+                name: event.name,
+                id: event.id,
+                result,
+              });
+
+              const messagePayload: Record<string, unknown> = {
+                schema: result.schema,
+                content: result.content,
+              };
+
+              if (result.data !== undefined) {
+                messagePayload.data = result.data;
+              }
+
+              if (result.metadata !== undefined) {
+                messagePayload.metadata = result.metadata;
+              }
+
               invocation.messages.push({
                 role: "tool",
                 name: event.name,
                 tool_call_id: event.id,
-                content: result.content,
+                content: JSON.stringify(messagePayload),
               });
 
               await this.dispatchHookOrThrow(
@@ -324,8 +344,7 @@ export class AgentOrchestratorService {
                   iteration,
                   id: event.id,
                   name: event.name,
-                  result: result.content,
-                  metadata: result.metadata,
+                  result,
                 },
               });
 

--- a/src/core/tools/builtin/bash.ts
+++ b/src/core/tools/builtin/bash.ts
@@ -16,12 +16,29 @@ export const bashTool: ToolDefinition = {
     required: ["command"],
     additionalProperties: false,
   },
+  outputSchema: {
+    $id: "eddie.tool.bash.result.v1",
+    type: "object",
+    properties: {
+      stdout: { type: "string" },
+      stderr: { type: "string" },
+    },
+    required: ["stdout", "stderr"],
+    additionalProperties: false,
+  },
   async handler(args, ctx) {
     const command = String(args.command ?? "");
     const timeoutMs = Number(args.timeoutMs ?? 15_000);
     const approved = await ctx.confirm(`Run command: ${command}`);
     if (!approved) {
-      return { content: "Command rejected by user." };
+      return {
+        schema: "eddie.tool.bash.result.v1",
+        content: "Command rejected by user.",
+        data: {
+          stdout: "",
+          stderr: "Command rejected by user.",
+        },
+      };
     }
 
     const { stdout, stderr } = await execAsync(command, {
@@ -31,7 +48,14 @@ export const bashTool: ToolDefinition = {
     });
 
     const output = stdout || stderr || "(no output)";
-    return { content: output };
+    return {
+      schema: "eddie.tool.bash.result.v1",
+      content: output,
+      data: {
+        stdout: stdout ?? "",
+        stderr: stderr ?? "",
+      },
+    };
   },
 };
 

--- a/src/core/tools/builtin/file_read.ts
+++ b/src/core/tools/builtin/file_read.ts
@@ -14,16 +14,37 @@ export const fileReadTool: ToolDefinition = {
     required: ["path"],
     additionalProperties: false,
   },
+  outputSchema: {
+    $id: "eddie.tool.file_read.result.v1",
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      bytes: { type: "number" },
+      truncated: { type: "boolean" },
+    },
+    required: ["path", "bytes", "truncated"],
+    additionalProperties: false,
+  },
   async handler(args, ctx) {
     const relPath = String(args.path ?? "");
     const absolute = path.resolve(ctx.cwd, relPath);
     const content = await fs.readFile(absolute, "utf-8");
     const maxBytes = args.maxBytes ? Number(args.maxBytes) : undefined;
+    const originalBytes = Buffer.byteLength(content, "utf-8");
     const slice =
-      maxBytes && Buffer.byteLength(content) > maxBytes
+      maxBytes && originalBytes > maxBytes
         ? content.slice(0, maxBytes)
         : content;
-    return { content: slice };
+    const truncated = Boolean(maxBytes && originalBytes > maxBytes);
+    return {
+      schema: "eddie.tool.file_read.result.v1",
+      content: slice,
+      data: {
+        path: relPath,
+        bytes: Buffer.byteLength(slice, "utf-8"),
+        truncated,
+      },
+    };
   },
 };
 

--- a/src/core/tools/builtin/file_write.ts
+++ b/src/core/tools/builtin/file_write.ts
@@ -14,18 +14,42 @@ export const fileWriteTool: ToolDefinition = {
     required: ["path", "content"],
     additionalProperties: false,
   },
+  outputSchema: {
+    $id: "eddie.tool.file_write.result.v1",
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      bytesWritten: { type: "number" },
+    },
+    required: ["path", "bytesWritten"],
+    additionalProperties: false,
+  },
   async handler(args, ctx) {
     const relPath = String(args.path ?? "");
     const content = String(args.content ?? "");
     const approved = await ctx.confirm(`Write file: ${relPath}`);
     if (!approved) {
-      return { content: "Write cancelled by user." };
+      return {
+        schema: "eddie.tool.file_write.result.v1",
+        content: "Write cancelled by user.",
+        data: {
+          path: relPath,
+          bytesWritten: 0,
+        },
+      };
     }
 
     const absolute = path.resolve(ctx.cwd, relPath);
     await fs.mkdir(path.dirname(absolute), { recursive: true });
     await fs.writeFile(absolute, content, "utf-8");
-    return { content: `Wrote ${relPath}` };
+    return {
+      schema: "eddie.tool.file_write.result.v1",
+      content: `Wrote ${relPath}`,
+      data: {
+        path: relPath,
+        bytesWritten: Buffer.byteLength(content, "utf-8"),
+      },
+    };
   },
 };
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -19,6 +19,29 @@ export interface ToolSchema {
   parameters: Record<string, unknown>;
 }
 
+export interface ToolResult<TData = unknown> {
+  /**
+   * Canonical identifier for the schema describing {@link ToolResult.data}.
+   * Enables consumers to safely discriminate between tool payload shapes.
+   */
+  schema: string;
+  /**
+   * Human-readable summary surfaced to the model and CLI logs.
+   */
+  content: string;
+  /**
+   * Structured JSON payload that adheres to the schema denoted by
+   * {@link ToolResult.schema}.
+   */
+  data?: TData;
+  /**
+   * Optional metadata emitted alongside the structured payload.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+export type ToolOutput<TData = unknown> = ToolResult<TData>;
+
 export type StreamEvent =
   | {
       type: "delta";
@@ -35,7 +58,7 @@ export type StreamEvent =
   | {
       type: "tool_result";
       name: string;
-      result: unknown;
+      result: ToolResult;
       id?: string;
     }
   | {
@@ -89,9 +112,9 @@ export interface ToolDefinition {
   name: string;
   description?: string;
   jsonSchema: Record<string, unknown>;
-  validate?: (data: unknown) => boolean;
+  outputSchema?: Record<string, unknown>;
   handler(
     args: ToolCallArguments,
     ctx: ToolExecutionContext,
-  ): Promise<{ content: string; metadata?: Record<string, unknown> }>;
+  ): Promise<ToolResult>;
 }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,4 +1,9 @@
-import type { ChatMessage, PackedContext, StreamEvent } from "../core/types";
+import type {
+  ChatMessage,
+  PackedContext,
+  StreamEvent,
+  ToolResult,
+} from "../core/types";
 import type { CliRuntimeOptions, EddieConfig } from "../config/types";
 
 /**
@@ -204,7 +209,7 @@ export interface AgentToolCallPayload extends AgentLifecyclePayload {
 export interface AgentToolResultPayload extends AgentLifecyclePayload {
   iteration: number;
   event: Extract<StreamEvent, { type: "tool_call" }>;
-  result: { content: string; metadata?: Record<string, unknown> };
+  result: ToolResult;
 }
 
 /**

--- a/src/io/stream-renderer.service.ts
+++ b/src/io/stream-renderer.service.ts
@@ -29,12 +29,17 @@ export class StreamRendererService {
         break;
       }
       case "tool_result": {
-        const summary =
-          typeof event.result === "string"
-            ? event.result
-            : JSON.stringify(event.result, null, 2);
+        const summary = redactSecrets(event.result.content, DEFAULT_PATTERNS);
+        const structured =
+          event.result.data !== undefined
+            ? ` ${redactSecrets(JSON.stringify(event.result.data, null, 2), DEFAULT_PATTERNS)}`
+            : "";
+        const metadata =
+          event.result.metadata && Object.keys(event.result.metadata).length > 0
+            ? ` ${redactSecrets(JSON.stringify(event.result.metadata), DEFAULT_PATTERNS)}`
+            : "";
         process.stdout.write(
-          `\n${chalk.green("[tool_result]")} ${event.name} ${summary}\n`
+          `\n${chalk.green("[tool_result]")} ${event.name} <${event.result.schema}> ${summary}${structured}${metadata}\n`
         );
         break;
       }

--- a/test/unit/core/tools/file_read.tool.test.ts
+++ b/test/unit/core/tools/file_read.tool.test.ts
@@ -28,7 +28,13 @@ describe("fileReadTool", () => {
       },
     );
 
+    expect(result.schema).toBe("eddie.tool.file_read.result.v1");
     expect(result.content).toBe("hello from ctx");
+    expect(result.data).toEqual({
+      path: fileName,
+      bytes: Buffer.byteLength("hello from ctx", "utf-8"),
+      truncated: false,
+    });
   });
 
   it("truncates content when maxBytes is provided", async () => {
@@ -47,6 +53,12 @@ describe("fileReadTool", () => {
       },
     );
 
+    expect(result.schema).toBe("eddie.tool.file_read.result.v1");
     expect(result.content).toBe("abc");
+    expect(result.data).toEqual({
+      path: fileName,
+      bytes: Buffer.byteLength("abc", "utf-8"),
+      truncated: true,
+    });
   });
 });

--- a/test/unit/core/tools/tool-registry.service.test.ts
+++ b/test/unit/core/tools/tool-registry.service.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { ToolRegistry } from "../../../../src/core/tools";
+
+const ctx = {
+  cwd: process.cwd(),
+  confirm: async () => true,
+  env: process.env,
+};
+
+describe("ToolRegistry", () => {
+  it("validates inputs and outputs against provided schemas", async () => {
+    const registry = new ToolRegistry([
+      {
+        name: "echo",
+        description: "Echo text",
+        jsonSchema: {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+          required: ["text"],
+          additionalProperties: false,
+        },
+        outputSchema: {
+          $id: "test.registry.echo.result",
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+          required: ["text"],
+          additionalProperties: false,
+        },
+        async handler(args) {
+          const text = String((args as { text: string }).text);
+          return {
+            schema: "test.registry.echo.result",
+            content: text,
+            data: { text },
+          };
+        },
+      },
+    ]);
+
+    const result = await registry.execute(
+      { name: "echo", arguments: { text: "hello" } },
+      ctx,
+    );
+
+    expect(result).toMatchObject({
+      schema: "test.registry.echo.result",
+      content: "hello",
+      data: { text: "hello" },
+    });
+
+    await expect(
+      registry.execute({ name: "echo", arguments: {} }, ctx),
+    ).rejects.toThrow(/Validation failed/);
+  });
+
+  it("throws when the tool output violates the declared schema", async () => {
+    const registry = new ToolRegistry([
+      {
+        name: "broken",
+        description: "Broken tool",
+        jsonSchema: {
+          type: "object",
+        },
+        outputSchema: {
+          $id: "test.registry.broken.result",
+          type: "object",
+          properties: {
+            value: { type: "number" },
+          },
+          required: ["value"],
+          additionalProperties: false,
+        },
+        async handler() {
+          return {
+            schema: "test.registry.broken.result",
+            content: "bad",
+            data: { value: "not-a-number" as unknown as number },
+          };
+        },
+      },
+    ]);
+
+    await expect(
+      registry.execute({ name: "broken", arguments: {} }, ctx),
+    ).rejects.toThrow(/Output validation failed/);
+  });
+
+  it("requires output schemas to provide a discriminator id", () => {
+    expect(
+      () =>
+        new ToolRegistry([
+          {
+            name: "missing",
+            description: "missing id",
+            jsonSchema: { type: "object" },
+            // @ts-expect-error intentionally omit $id to assert runtime guard
+            outputSchema: {
+              type: "object",
+            },
+            async handler() {
+              return {
+                schema: "missing",
+                content: "",
+              };
+            },
+          },
+        ]),
+    ).toThrow(/output schema must declare a string \$id/);
+  });
+
+  it("fails when structured data is omitted despite declaring a schema", async () => {
+    const registry = new ToolRegistry([
+      {
+        name: "nodata",
+        description: "missing data",
+        jsonSchema: {
+          type: "object",
+        },
+        outputSchema: {
+          $id: "test.registry.nodata.result",
+          type: "object",
+          properties: {
+            value: { type: "string" },
+          },
+          required: ["value"],
+          additionalProperties: false,
+        },
+        async handler() {
+          return {
+            schema: "test.registry.nodata.result",
+            content: "",
+            // intentionally omit data
+          };
+        },
+      },
+    ]);
+
+    await expect(
+      registry.execute({ name: "nodata", arguments: {} }, ctx),
+    ).rejects.toThrow(/structured data missing/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a ToolResult type and extend the registry to validate both tool inputs and outputs
- update built-in tools, orchestration, and stream rendering to emit structured tool payloads
- add unit tests covering schema enforcement and structured result propagation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e58469ff8883289685cdb5d3d2f310