### PR TITLE
feat: integrate MCP tool sources

### DIFF
--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -11,6 +11,7 @@ import type {
   EddieConfig,
   EddieConfigInput,
   LoggingConfig,
+  ToolsConfig,
 } from "./types";
 
 const CONFIG_FILENAMES = [
@@ -365,6 +366,8 @@ export class ConfigService {
   }
 
   private validateConfig(config: EddieConfig): void {
+    this.validateToolsConfig(config.tools);
+
     const { agents } = config;
 
     if (!agents) {
@@ -480,5 +483,112 @@ export class ConfigService {
         }
       }
     }
+  }
+
+  private validateToolsConfig(tools: ToolsConfig | undefined): void {
+    if (!tools?.sources) {
+      return;
+    }
+
+    if (!Array.isArray(tools.sources)) {
+      throw new Error("tools.sources must be an array when provided.");
+    }
+
+    tools.sources.forEach((source, index) => {
+      if (!source || typeof source !== "object") {
+        throw new Error(`tools.sources[${index}] must be an object.`);
+      }
+
+      if (source.type !== "mcp") {
+        throw new Error(
+          `tools.sources[${index}].type must be the literal string \"mcp\".`
+        );
+      }
+
+      if (typeof source.id !== "string" || source.id.trim() === "") {
+        throw new Error(
+          `tools.sources[${index}].id must be provided as a non-empty string.`
+        );
+      }
+
+      if (typeof source.url !== "string" || source.url.trim() === "") {
+        throw new Error(
+          `tools.sources[${index}].url must be provided as a non-empty string.`
+        );
+      }
+
+      if (
+        typeof source.name !== "undefined" &&
+        (typeof source.name !== "string" || source.name.trim() === "")
+      ) {
+        throw new Error(
+          `tools.sources[${index}].name must be a non-empty string when provided.`
+        );
+      }
+
+      if (typeof source.headers !== "undefined") {
+        if (
+          !source.headers ||
+          typeof source.headers !== "object" ||
+          Array.isArray(source.headers)
+        ) {
+          throw new Error(
+            `tools.sources[${index}].headers must be an object with string values when provided.`
+          );
+        }
+
+        for (const [key, value] of Object.entries(source.headers)) {
+          if (typeof value !== "string") {
+            throw new Error(
+              `tools.sources[${index}].headers.${key} must be a string.`
+            );
+          }
+        }
+      }
+
+      if (typeof source.auth !== "undefined") {
+        const auth = source.auth;
+        if (!auth || typeof auth !== "object") {
+          throw new Error(
+            `tools.sources[${index}].auth must be an object when provided.`
+          );
+        }
+
+        if (auth.type === "basic") {
+          if (
+            typeof auth.username !== "string" ||
+            auth.username.trim() === "" ||
+            typeof auth.password !== "string"
+          ) {
+            throw new Error(
+              `tools.sources[${index}].auth must include non-empty username and password for basic auth.`
+            );
+          }
+        } else if (auth.type === "bearer") {
+          if (typeof auth.token !== "string" || auth.token.trim() === "") {
+            throw new Error(
+              `tools.sources[${index}].auth.token must be a non-empty string for bearer auth.`
+            );
+          }
+        } else if (auth.type === "none") {
+          // nothing additional
+        } else {
+          throw new Error(
+            `tools.sources[${index}].auth.type must be one of "basic", "bearer", or "none".`
+          );
+        }
+      }
+
+      if (
+        typeof source.capabilities !== "undefined" &&
+        (typeof source.capabilities !== "object" ||
+          source.capabilities === null ||
+          Array.isArray(source.capabilities))
+      ) {
+        throw new Error(
+          `tools.sources[${index}].capabilities must be an object when provided.`
+        );
+      }
+    });
   }
 }

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -501,7 +501,7 @@ export class ConfigService {
 
       if (source.type !== "mcp") {
         throw new Error(
-          `tools.sources[${index}].type must be the literal string \"mcp\".`
+          `tools.sources[${index}].type must be the literal string "mcp".`
         );
       }
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -30,6 +30,7 @@ export const DEFAULT_CONFIG: EddieConfig = {
   tools: {
     enabled: ["bash", "file_read", "file_write"],
     autoApprove: false,
+    sources: [],
   },
   hooks: {
     modules: [],

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -117,10 +117,49 @@ export interface OutputConfig {
   prettyStream?: boolean;
 }
 
+export interface MCPBasicAuthConfig {
+  type: "basic";
+  username: string;
+  password: string;
+}
+
+export interface MCPBearerAuthConfig {
+  type: "bearer";
+  token: string;
+}
+
+export interface MCPNoAuthConfig {
+  type: "none";
+}
+
+export type MCPAuthConfig =
+  | MCPBasicAuthConfig
+  | MCPBearerAuthConfig
+  | MCPNoAuthConfig;
+
+export interface MCPToolSourceCapabilitiesConfig {
+  tools?: Record<string, unknown>;
+  resources?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface MCPToolSourceConfig {
+  id: string;
+  type: "mcp";
+  url: string;
+  name?: string;
+  headers?: Record<string, string>;
+  auth?: MCPAuthConfig;
+  capabilities?: MCPToolSourceCapabilitiesConfig;
+}
+
+export type ToolSourceConfig = MCPToolSourceConfig;
+
 export interface ToolsConfig {
   enabled?: string[];
   disabled?: string[];
   autoApprove?: boolean;
+  sources?: ToolSourceConfig[];
 }
 
 export interface HooksConfig {

--- a/src/core/engine/engine.module.ts
+++ b/src/core/engine/engine.module.ts
@@ -8,6 +8,7 @@ import { TokenizersModule } from "../tokenizers";
 import { EngineService } from "./engine.service";
 import { ToolsModule } from "../tools";
 import { AgentInvocationFactory, AgentOrchestratorService } from "../agents";
+import { McpToolSourceService } from "../../integrations";
 
 @Module({
   imports: [
@@ -19,7 +20,12 @@ import { AgentInvocationFactory, AgentOrchestratorService } from "../agents";
     TokenizersModule,
     ToolsModule,
   ],
-  providers: [EngineService, AgentInvocationFactory, AgentOrchestratorService],
+  providers: [
+    EngineService,
+    AgentInvocationFactory,
+    AgentOrchestratorService,
+    McpToolSourceService,
+  ],
   exports: [
     EngineService,
     AgentOrchestratorService,

--- a/src/core/engine/engine.module.ts
+++ b/src/core/engine/engine.module.ts
@@ -8,7 +8,7 @@ import { TokenizersModule } from "../tokenizers";
 import { EngineService } from "./engine.service";
 import { ToolsModule } from "../tools";
 import { AgentInvocationFactory, AgentOrchestratorService } from "../agents";
-import { McpToolSourceService } from "../../integrations";
+import { MCPModule } from "../../integrations";
 
 @Module({
   imports: [
@@ -19,12 +19,12 @@ import { McpToolSourceService } from "../../integrations";
     ProvidersModule,
     TokenizersModule,
     ToolsModule,
+    MCPModule,
   ],
   providers: [
     EngineService,
     AgentInvocationFactory,
     AgentOrchestratorService,
-    McpToolSourceService,
   ],
   exports: [
     EngineService,

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1,0 +1,5 @@
+export { McpToolSourceService } from "./mcp/mcp-tool-source.service";
+export type {
+  McpToolSourceDiscovery,
+  McpResourceDescription,
+} from "./mcp/mcp-tool-source.service";

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1,5 +1,10 @@
+export { MCPModule } from "./mcp/mcp.module";
 export { McpToolSourceService } from "./mcp/mcp-tool-source.service";
 export type {
   McpToolSourceDiscovery,
   McpResourceDescription,
-} from "./mcp/mcp-tool-source.service";
+  McpInitializeResult,
+  McpToolDescription,
+  McpToolsListResult,
+  McpResourcesListResult,
+} from "./mcp/types";

--- a/src/integrations/mcp/mcp-tool-source.service.ts
+++ b/src/integrations/mcp/mcp-tool-source.service.ts
@@ -1,0 +1,305 @@
+import { Injectable } from "@nestjs/common";
+import { Buffer } from "buffer";
+import type {
+  MCPToolSourceConfig,
+  MCPAuthConfig,
+} from "../../config/types";
+import type { ToolDefinition, ToolResult, ToolCallArguments } from "../../core/types";
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcSuccess<T> {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result: T;
+}
+
+interface JsonRpcError {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcError;
+
+interface McpInitializeResult {
+  sessionId?: string;
+  protocolVersion?: string;
+  capabilities?: Record<string, unknown>;
+  serverInfo?: Record<string, unknown>;
+}
+
+interface McpToolDescription {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+}
+
+export interface McpResourceDescription {
+  name: string;
+  uri: string;
+  description?: string;
+  mimeType?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface McpToolsListResult {
+  tools?: McpToolDescription[];
+}
+
+interface McpResourcesListResult {
+  resources?: McpResourceDescription[];
+}
+
+export interface McpToolSourceDiscovery {
+  sourceId: string;
+  tools: ToolDefinition[];
+  resources: McpResourceDescription[];
+}
+
+@Injectable()
+export class McpToolSourceService {
+  private requestCounter = 0;
+
+  async collectTools(
+    sources: MCPToolSourceConfig[] | undefined
+  ): Promise<ToolDefinition[]> {
+    const discoveries = await this.discoverSources(sources);
+    return discoveries.flatMap((entry) => entry.tools);
+  }
+
+  async discoverSources(
+    sources: MCPToolSourceConfig[] | undefined
+  ): Promise<McpToolSourceDiscovery[]> {
+    if (!sources?.length) {
+      return [];
+    }
+
+    const discoveries: McpToolSourceDiscovery[] = [];
+    for (const source of sources) {
+      const discovery = await this.discoverSource(source);
+      discoveries.push({
+        sourceId: source.id,
+        tools: discovery.tools,
+        resources: discovery.resources,
+      });
+    }
+
+    return discoveries;
+  }
+
+  private async discoverSource(source: MCPToolSourceConfig): Promise<{
+    tools: ToolDefinition[];
+    resources: McpResourceDescription[];
+  }> {
+    const sessionId = await this.initialize(source);
+    const tools = await this.listTools(source, sessionId);
+    const resources = await this.listResources(source, sessionId);
+
+    const toolDefinitions = tools.map((tool) =>
+      this.toToolDefinition(source, sessionId, tool)
+    );
+
+    return { tools: toolDefinitions, resources };
+  }
+
+  private async initialize(source: MCPToolSourceConfig): Promise<string | undefined> {
+    const result = await this.sendJsonRpc<McpInitializeResult>(
+      source,
+      "initialize",
+      {
+        clientInfo: { name: "eddie", version: "unknown" },
+        capabilities: source.capabilities ?? {},
+      }
+    );
+
+    return result.sessionId;
+  }
+
+  private async listTools(
+    source: MCPToolSourceConfig,
+    sessionId?: string
+  ): Promise<McpToolDescription[]> {
+    const params = sessionId ? { sessionId } : undefined;
+    const result = await this.sendJsonRpc<McpToolsListResult>(
+      source,
+      "tools/list",
+      params
+    );
+    return (result.tools ?? []).map((tool) => ({
+      ...tool,
+      inputSchema: structuredClone(tool.inputSchema),
+      outputSchema: tool.outputSchema
+        ? structuredClone(tool.outputSchema)
+        : undefined,
+    }));
+  }
+
+  private async listResources(
+    source: MCPToolSourceConfig,
+    sessionId?: string
+  ): Promise<McpResourceDescription[]> {
+    const params = sessionId ? { sessionId } : undefined;
+    const result = await this.sendJsonRpc<McpResourcesListResult>(
+      source,
+      "resources/list",
+      params
+    );
+    return (result.resources ?? []).map((resource) => ({
+      ...resource,
+      metadata: resource.metadata ? structuredClone(resource.metadata) : undefined,
+    }));
+  }
+
+  private toToolDefinition(
+    source: MCPToolSourceConfig,
+    sessionId: string | undefined,
+    descriptor: McpToolDescription
+  ): ToolDefinition {
+    const jsonSchema = structuredClone(descriptor.inputSchema);
+    const outputSchema = descriptor.outputSchema
+      ? structuredClone(descriptor.outputSchema)
+      : undefined;
+
+    return {
+      name: descriptor.name,
+      description: descriptor.description,
+      jsonSchema,
+      ...(outputSchema ? { outputSchema } : {}),
+      handler: async (args: ToolCallArguments) => {
+        const result = await this.callTool(source, sessionId, descriptor.name, args);
+        if (
+          !result ||
+          typeof result !== "object" ||
+          typeof result.schema !== "string" ||
+          typeof result.content !== "string"
+        ) {
+          throw new Error(
+            `Tool ${descriptor.name} returned an invalid result payload from MCP source ${source.id}.`
+          );
+        }
+
+        const clonedResult: ToolResult = {
+          schema: result.schema,
+          content: result.content,
+          data:
+            result.data !== undefined
+              ? structuredClone(result.data)
+              : undefined,
+          metadata:
+            result.metadata !== undefined
+              ? structuredClone(result.metadata)
+              : undefined,
+        };
+
+        return clonedResult;
+      },
+    };
+  }
+
+  private async callTool(
+    source: MCPToolSourceConfig,
+    sessionId: string | undefined,
+    name: string,
+    args: ToolCallArguments
+  ): Promise<ToolResult> {
+    const params: Record<string, unknown> = {
+      name,
+      arguments: structuredClone(args ?? {}),
+    };
+
+    if (sessionId) {
+      params.sessionId = sessionId;
+    }
+
+    return this.sendJsonRpc<ToolResult>(source, "tools/call", params);
+  }
+
+  private async sendJsonRpc<T>(
+    source: MCPToolSourceConfig,
+    method: string,
+    params?: unknown
+  ): Promise<T> {
+    const id = `${source.id}-${++this.requestCounter}`;
+    const request: JsonRpcRequest = {
+      jsonrpc: "2.0",
+      id,
+      method,
+    };
+
+    if (typeof params !== "undefined") {
+      request.params = params;
+    }
+
+    const headers = this.buildHeaders(source);
+    const response = await fetch(source.url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(
+        `MCP request to ${source.url} failed with status ${response.status}: ${body}`
+      );
+    }
+
+    const payload = (await response.json()) as JsonRpcResponse<T>;
+    if ("error" in payload) {
+      throw new Error(
+        `MCP request for ${method} failed: ${payload.error.message}`,
+        payload.error.data ? { cause: payload.error } : undefined
+      );
+    }
+
+    return payload.result;
+  }
+
+  private buildHeaders(source: MCPToolSourceConfig): Record<string, string> {
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      "content-type": "application/json",
+      ...(source.headers ?? {}),
+    };
+
+    const hasAuthorizationHeader = Object.keys(headers).some(
+      (key) => key.toLowerCase() === "authorization"
+    );
+
+    if (!hasAuthorizationHeader && source.auth) {
+      const authorization = this.computeAuthorization(source.auth);
+      if (authorization) {
+        headers.Authorization = authorization;
+      }
+    }
+
+    return headers;
+  }
+
+  private computeAuthorization(auth: MCPAuthConfig): string {
+    switch (auth.type) {
+      case "basic": {
+        const encoded = Buffer.from(`${auth.username}:${auth.password}`).toString(
+          "base64"
+        );
+        return `Basic ${encoded}`;
+      }
+      case "bearer":
+        return `Bearer ${auth.token}`;
+      case "none":
+      default:
+        return "";
+    }
+  }
+}

--- a/src/integrations/mcp/mcp-tool-source.service.ts
+++ b/src/integrations/mcp/mcp-tool-source.service.ts
@@ -4,68 +4,17 @@ import type {
   MCPToolSourceConfig,
   MCPAuthConfig,
 } from "../../config/types";
+import type {
+  McpInitializeResult,
+  McpResourceDescription,
+  McpResourcesListResult,
+  McpToolDescription,
+  McpToolSourceDiscovery,
+  McpToolsListResult,
+  JsonRpcRequest,
+  JsonRpcResponse,
+} from "./types";
 import type { ToolDefinition, ToolResult, ToolCallArguments } from "../../core/types";
-
-interface JsonRpcRequest {
-  jsonrpc: "2.0";
-  id: string;
-  method: string;
-  params?: unknown;
-}
-
-interface JsonRpcSuccess<T> {
-  jsonrpc: "2.0";
-  id: string | number | null;
-  result: T;
-}
-
-interface JsonRpcError {
-  jsonrpc: "2.0";
-  id: string | number | null;
-  error: {
-    code: number;
-    message: string;
-    data?: unknown;
-  };
-}
-
-type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcError;
-
-interface McpInitializeResult {
-  sessionId?: string;
-  protocolVersion?: string;
-  capabilities?: Record<string, unknown>;
-  serverInfo?: Record<string, unknown>;
-}
-
-interface McpToolDescription {
-  name: string;
-  description?: string;
-  inputSchema: Record<string, unknown>;
-  outputSchema?: Record<string, unknown>;
-}
-
-export interface McpResourceDescription {
-  name: string;
-  uri: string;
-  description?: string;
-  mimeType?: string;
-  metadata?: Record<string, unknown>;
-}
-
-interface McpToolsListResult {
-  tools?: McpToolDescription[];
-}
-
-interface McpResourcesListResult {
-  resources?: McpResourceDescription[];
-}
-
-export interface McpToolSourceDiscovery {
-  sourceId: string;
-  tools: ToolDefinition[];
-  resources: McpResourceDescription[];
-}
 
 @Injectable()
 export class McpToolSourceService {

--- a/src/integrations/mcp/mcp.module.ts
+++ b/src/integrations/mcp/mcp.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { McpToolSourceService } from "./mcp-tool-source.service";
+
+@Module({
+  providers: [McpToolSourceService],
+  exports: [McpToolSourceService],
+})
+export class MCPModule {}

--- a/src/integrations/mcp/types.ts
+++ b/src/integrations/mcp/types.ts
@@ -1,0 +1,62 @@
+import type { ToolDefinition } from "../../core/types";
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcSuccess<T> {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result: T;
+}
+
+export interface JsonRpcError {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcError;
+
+export interface McpInitializeResult {
+  sessionId?: string;
+  protocolVersion?: string;
+  capabilities?: Record<string, unknown>;
+  serverInfo?: Record<string, unknown>;
+}
+
+export interface McpToolDescription {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+}
+
+export interface McpResourceDescription {
+  name: string;
+  uri: string;
+  description?: string;
+  mimeType?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface McpToolsListResult {
+  tools?: McpToolDescription[];
+}
+
+export interface McpResourcesListResult {
+  resources?: McpResourceDescription[];
+}
+
+export interface McpToolSourceDiscovery {
+  sourceId: string;
+  tools: ToolDefinition[];
+  resources: McpResourceDescription[];
+}

--- a/test/unit/core/engine/engine.service.test.ts
+++ b/test/unit/core/engine/engine.service.test.ts
@@ -22,6 +22,7 @@ import type { HooksService } from "../../../../src/hooks";
 import type { ConfirmService } from "../../../../src/io";
 import { LoggerService } from "../../../../src/io";
 import type { TokenizerService } from "../../../../src/core/tokenizers";
+import type { McpToolSourceService } from "../../../../src/integrations";
 
 class FakeAgentOrchestrator {
   shouldFail = false;
@@ -129,6 +130,9 @@ function createEngineHarness(
   } as unknown as TokenizerService;
 
   const loggerService = new LoggerService();
+  const mcpToolSourceService = {
+    collectTools: vi.fn(async () => []),
+  } as unknown as McpToolSourceService;
 
   const fakeOrchestrator = new FakeAgentOrchestrator();
   if (overrides?.orchestratorShouldFail) {
@@ -143,7 +147,8 @@ function createEngineHarness(
     confirmService,
     tokenizerService,
     loggerService,
-    fakeOrchestrator as unknown as AgentOrchestratorService
+    fakeOrchestrator as unknown as AgentOrchestratorService,
+    mcpToolSourceService
   );
 
   return {


### PR DESCRIPTION
## Summary
- extend the tools configuration schema with MCP remote source support and validation
- implement an MCP tool source client, merge discovered tools into the engine, and expose the integration module
- exercise the MCP workflow with integration coverage and update engine unit tests for the new dependency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5879ac594832881e7e249351b4198