### PR TITLE
fix: restore logger setup and hook bus wiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "build": "nest build",
         "lint": "eslint 'src/**/*.ts'",
         "test": "vitest --run",
+        "start": "nest start",
         "dev": "nest start --watch"
     },
     "repository": {

--- a/src/core/agents/agent-invocation.factory.ts
+++ b/src/core/agents/agent-invocation.factory.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import type { TemplateVariables } from "../../shared/template.types";
 import type { PackedContext } from "../types";
-import type { ToolRegistryFactory } from "../tools/tool-registry.service";
+import { ToolRegistryFactory } from "../tools/tool-registry.service";
 import { TemplateRendererService } from "../templates/template-renderer.service";
 import type { AgentDefinition } from "./agent-definition";
 import { AgentInvocation, type AgentInvocationOptions } from "./agent-invocation";

--- a/src/core/agents/agent-orchestrator.service.ts
+++ b/src/core/agents/agent-orchestrator.service.ts
@@ -3,11 +3,11 @@ import type { Logger } from "pino";
 import { JsonlWriterService } from "../../io/jsonl-writer.service";
 import { StreamRendererService } from "../../io/stream-renderer.service";
 import { HOOK_EVENTS } from "../../hooks/types";
+import type { HookBus } from "../../hooks/hook-bus.service";
 import type {
   AgentLifecyclePayload,
   AgentMetadata,
   AgentTranscriptCompactionPayload,
-  HookBus,
   HookDispatchResult,
   HookEventMap,
   HookEventName,

--- a/src/core/engine/engine.service.ts
+++ b/src/core/engine/engine.service.ts
@@ -11,8 +11,8 @@ import { ConfirmService } from "../../io/confirm.service";
 import { LoggerService } from "../../io/logger.service";
 import { HooksService } from "../../hooks/hooks.service";
 import { HOOK_EVENTS } from "../../hooks/types";
+import type { HookBus } from "../../hooks/hook-bus.service";
 import type {
-  HookBus,
   HookDispatchResult,
   HookEventName,
   SessionMetadata,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,7 @@ import { AppModule } from "./app.module";
 import { CliRunnerService } from "./cli/cli-runner.service";
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.createApplicationContext(AppModule, {
-    logger: false,
-  });
+  const app = await NestFactory.createApplicationContext(AppModule);
 
   let exitCode = 0;
 


### PR DESCRIPTION
## Summary
- allow the Nest bootstrap to use the configured logger instead of disabling it
- update HookBus imports to reference the service and ensure ToolRegistryFactory is injected at runtime

## Testing
- npx nest start -- chat
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5a9194d5c8328919112e5aa6ee598