### PR TITLE
refactor: migrate openai adapter to responses api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "eta": "^3.5.0",
                 "fast-glob": "^3.3.3",
                 "ignore": "^7.0.5",
+                "openai": "^6.2.0",
                 "pino": "^10.0.0",
                 "reflect-metadata": "^0.2.2",
                 "tiktoken-node": "^0.0.7",
@@ -4933,6 +4934,27 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/openai": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-6.2.0.tgz",
+            "integrity": "sha512-qqjzHls7F5xkXNGy9P1Ei1rorI5LWupUUFWP66zPU8FlZbiITX8SFcHMKNZg/NATJ0LpIZcMUFxSwQmdeQPwSw==",
+            "license": "Apache-2.0",
+            "bin": {
+                "openai": "bin/cli"
+            },
+            "peerDependencies": {
+                "ws": "^8.18.0",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "ws": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": true
+                }
             }
         },
         "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "eta": "^3.5.0",
         "fast-glob": "^3.3.3",
         "ignore": "^7.0.5",
+        "openai": "^6.2.0",
         "pino": "^10.0.0",
         "reflect-metadata": "^0.2.2",
         "tiktoken-node": "^0.0.7",


### PR DESCRIPTION
## Summary
- replace the manual chat completions fetcher with the OpenAI SDK responses stream implementation
- handle streamed text, tool calls, and usage tracking from the responses API and add resilient fallbacks
- update unit coverage to mock the OpenAI client and add the OpenAI dependency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5bb85041883289e59d47eb7c38afd