### PR TITLE
fix: align OpenAI provider types with latest responses API

### DIFF
--- a/src/core/providers/openai.ts
+++ b/src/core/providers/openai.ts
@@ -5,7 +5,6 @@ import type {
   ResponseFunctionToolCall,
   ResponseTextConfig,
 } from "openai/resources/responses/responses";
-import type { ResponseCreateAndStreamParams } from "openai/lib/responses/ResponseStream";
 import type { ProviderConfig } from "../../config/types";
 import type { ProviderAdapter, StreamEvent, StreamOptions, ToolSchema } from "../types";
 import type { ProviderAdapterFactory } from "./provider.tokens";
@@ -16,7 +15,11 @@ interface OpenAIConfig {
   apiKey?: string;
 }
 
-type ResponseStreamCreateParams = ResponseCreateAndStreamParams;
+type ResponseStreamParams = Parameters<OpenAI["responses"]["stream"]>[0];
+type ResponseStreamCreateParams = Extract<
+  ResponseStreamParams,
+  { input?: unknown }
+>;
 type ResponseTools = NonNullable<ResponseStreamCreateParams["tools"]>;
 type ResponseTool = ResponseTools extends Array<infer Tool>
   ? Tool

--- a/test/unit/core/providers/openai.adapter.test.ts
+++ b/test/unit/core/providers/openai.adapter.test.ts
@@ -43,7 +43,7 @@ describe("OpenAIAdapter", () => {
     streamMock.mockClear();
   });
 
-  it("formats tools according to the chat/completions schema", async () => {
+  it("formats tools according to the Responses API schema", async () => {
     const adapter = new OpenAIAdapter({});
 
     const iterator = adapter.stream({
@@ -67,11 +67,10 @@ describe("OpenAIAdapter", () => {
     expect((requestBody as { tools?: unknown }).tools).toEqual([
       {
         type: "function",
-        function: {
-          name: "echo",
-          description: "Echo a value",
-          parameters: { type: "object" },
-        },
+        name: "echo",
+        description: "Echo a value",
+        parameters: { type: "object" },
+        strict: true,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- update the OpenAI adapter to use the latest responses streaming types and request shape
- adjust tool serialization and metadata/response format handling for the new API
- harden final response handling when the stream completes with errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5cdacb0fc8328ad6207a38345660e