### PR TITLE
fix: disable strict tool enforcement for OpenAI provider

### DIFF
--- a/src/core/providers/openai.ts
+++ b/src/core/providers/openai.ts
@@ -239,7 +239,7 @@ export class OpenAIAdapter implements ProviderAdapter {
       name: tool.name,
       description: tool.description ?? null,
       parameters: tool.parameters ?? null,
-      strict: true,
+      strict: false,
     }));
   }
 

--- a/test/unit/core/providers/openai.adapter.test.ts
+++ b/test/unit/core/providers/openai.adapter.test.ts
@@ -70,7 +70,7 @@ describe("OpenAIAdapter", () => {
         name: "echo",
         description: "Echo a value",
         parameters: { type: "object" },
-        strict: true,
+        strict: false,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- configure the OpenAI provider to set tool strict mode to false when calling the Responses API
- update the OpenAI adapter unit test to reflect the relaxed strict flag

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5dc645500832893e23a8b2e4c0f77