### PR TITLE
feat: improve OpenAI stream tool handling

### DIFF
--- a/src/core/providers/openai_compatible.ts
+++ b/src/core/providers/openai_compatible.ts
@@ -42,6 +42,7 @@ export class OpenAICompatibleAdapter implements ProviderAdapter {
         stream: true,
         messages: options.messages,
         tools: formattedTools,
+        tool_choice: formattedTools ? "auto" : undefined,
       }),
     });
 


### PR DESCRIPTION
## Summary
- handle the `response.output_item.added` event in the OpenAI provider so streamed tool calls retain their identifiers and metadata
- track tool call identifiers across stream events to avoid duplicates and prefer call IDs when emitting tool call payloads
- include `tool_choice: "auto"` in OpenAI-compatible streaming requests when tools are provided

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5f260e7448328abc36c8b26758951